### PR TITLE
fix for windows directory browsing 

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1077,7 +1077,7 @@ static int child(struct config *conf, struct config *cconf, const char *client, 
 			}
 			else if(!strncmp(buf, "listb ", strlen("listb ")))
 			{
-				if((browsedir=strrchr(buf, ':')))
+				if((browsedir=strchr(buf, ':')))
 				{
 					*browsedir='\0';
 					browsedir++;


### PR DESCRIPTION
Server was mis-parsing listb request with a windows path containing colon, i.e.
burp -aL -b4 -dC:/
would attempt to list / instead of C:/ (because it searched for the last colon, instead of the first, in order to split the parameter list from the client).

Please review and pull.
