### PR TITLE
fixed: restore w/ overwrite by linux client and split vss

### DIFF
--- a/src/restore_client.c
+++ b/src/restore_client.c
@@ -560,7 +560,15 @@ static int overwrite_ok(struct sbuf *sb, struct config *conf, BFILE *bfd, const 
 	struct stat checkstat;
 
 	// User specified overwrite is OK.
+#ifdef HAVE_WIN32
 	if(conf->overwrite) return 1;
+#else
+	// User specified overwrite is OK,
+	// UNLESS we're trying to overwrite the file with the trailing VSS data
+	if(conf->overwrite)
+		return (sb->cmd!=CMD_VSS_T
+			&& sb->cmd!=CMD_ENC_VSS_T);
+#endif
 
 	if(!S_ISDIR(sb->statp.st_mode)
 	  && sb->cmd!=CMD_METADATA


### PR DESCRIPTION
###### Setup:

`win-client` is a windows client configured with `split_vss=1` 
`linux-client` in a linux client configured as `restore_client` for `win-client`.
###### Problem:

When running the following on `linux-client` (note the `-f` option)

```
 burp -C win-client -a r -f -d <restore path> -b <#backup> -r <regexp>
```

`burp` first overwrites any existing file at the destination with restored file data and then overwrites that with the vss footer of each file - end result is that we're left with just the vss footer.
###### Fix:

on linux: prevent overwrite of file when considering vss footer in `overwrite_ok`

Please review and pull.
Thanks,
Avi
