### PR TITLE
fixed: autoupgrade fails on windows if autoupgrade_dir has been modified

### DIFF
--- a/configs/server/autoupgrade/windows.script
+++ b/configs/server/autoupgrade/windows.script
@@ -4,5 +4,7 @@ REM But still want old installations to work.
 IF EXIST "C:\Program Files\Burp\autoupgrade\package.exe" (
 	"C:\Program Files\Burp\autoupgrade\package.exe" /S
 ) ELSE (
-	"%PROGRAMFILES%\Burp\autoupgrade\package.exe" /S
+	IF EXIST "%~dp0\package.exe" (
+		"%~dp0\package.exe" /S
+	)
 )


### PR DESCRIPTION
If `autoupgrade_dir` is modified on a windows client, burp fetches files (`package.exe` and `script.bat`) from the server to the correct path, but the installation batch file fails because it references a different directory than the one it is in. I fixed this using [batch parameter modifiers](http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/percent.mspx?mfr=true) in `script.bat`.

Please review and pull.
