### PR TITLE
win32: prevent system from entering sleep when idle timer expires

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -540,11 +540,23 @@ end:
 int client(struct config *conf, enum action act, int vss_restore, int json)
 {
 	int ret=0;
+	
+#if defined(HAVE_WIN32)
+	// prevent sleep when idle
+	SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+#endif
+	
 	if((ret=do_client(conf, act, vss_restore, json))==1)
 	{
 		logp("Re-opening connection to server\n");
 		sleep(5);
 		ret=do_client(conf, act, vss_restore, json);
 	}
+	
+#if defined(HAVE_WIN32)
+	// allow sleep when idle
+	SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+	
 	return ret;
 }


### PR DESCRIPTION
Backup and other long running operations may be interrupted by the client machine entering sleep when the idle timer expires. 

I've seen this happen on two windows 7 laptops: during backup, the client machine goes to sleep, and the burp server does not notice this for a long while. Eventually, the burp server will report this as "client crashed" while the burp client aborts the operation on its side as soon the client machine wakes up.

The fix is to use the [`SetThreadExecutionState`](http://msdn.microsoft.com/en-us/library/windows/desktop/aa373208%28v=vs.85%29.aspx) Windows API to prevent sleep before any operation starts, and allow sleep after the client is done.

Please review and pull.
