### PR TITLE
cleaned up some valgrind errors and memory leaks in client mode

### DIFF
--- a/src/asyncio.c
+++ b/src/asyncio.c
@@ -505,7 +505,7 @@ int async_write_str(char wcmd, const char *wsrc)
 int async_read_expect(char cmd, const char *expect)
 {
 	int ret=0;
-	char rcmd;
+	char rcmd=0;
 	char *rdst=NULL;
 	size_t rlen=0;
 	if(async_read(&rcmd, &rdst, &rlen)) return -1;
@@ -663,6 +663,7 @@ int async_read_stat(FILE *fp, gzFile zp, struct sbuf *sb, struct cntr *cntr)
 		  || (cmd==CMD_GEN && !strcmp(buf, "backupphase2"))
 		  || (cmd==CMD_GEN && !strcmp(buf, "estimateend")))
 		{
+			if(buf) free(buf);
 			if(d) free(d);
 			return 1;
 		}

--- a/src/auth_client.c
+++ b/src/auth_client.c
@@ -13,7 +13,7 @@
 
 int authorise_client(struct config *conf, char **server_version, struct cntr *p1cntr)
 {
-	char cmd;
+	char cmd=0;
 	char *buf=NULL;
 	size_t l=0;
 	char hello[256]="";
@@ -79,5 +79,8 @@ int authorise_client(struct config *conf, char **server_version, struct cntr *p1
 		return -1;
 	}
 
+	if (buf)
+		free(buf);
+	
 	return 0;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -25,7 +25,7 @@
 // Return 0 for OK, -1 for error, 1 for timer conditions not met.
 static int maybe_check_timer(const char *phase1str, struct config *conf, int *resume)
 {
-	char rcmd;
+	char rcmd=0;
 	char *rdst=NULL;
 	size_t rlen=0;
 	int complen=0;
@@ -217,7 +217,7 @@ static int do_client(struct config *conf, enum action act, int vss_restore, int 
 
 	if(act!=ACTION_ESTIMATE)
 	{
-		char cmd;
+		char cmd=0;
 		size_t len=0;
 		char *feat=NULL;
 		int ca_ret=0;

--- a/src/conf.c
+++ b/src/conf.c
@@ -196,6 +196,7 @@ void init_config(struct config *conf)
 void free_config(struct config *conf)
 {
 	if(!conf) return;
+	if(conf->port) free(conf->port);
 	if(conf->configfile) free(conf->configfile);
 	if(conf->clientconfdir) free(conf->clientconfdir);
 	if(conf->cname) free(conf->cname);

--- a/src/handy.c
+++ b/src/handy.c
@@ -883,7 +883,7 @@ int init_client_socket(const char *host, const char *port)
 
 void reuseaddr(int fd)
 {
-	int tmpfd;
+	int tmpfd=0;
 	if(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR,
 		(sockopt_val_t)&tmpfd, sizeof(tmpfd))<0)
 			logp("Error: setsockopt SO_REUSEADDR: %s",

--- a/src/incexc_send.c
+++ b/src/incexc_send.c
@@ -12,15 +12,18 @@
 static int send_incexc_str(const char *pre, const char *str)
 {
 	char *tosend=NULL;
+	int rc=0;
 	if(!str) return 0;
 	if(!(tosend=prepend(pre, str, strlen(str), " = ")))
-		return -1;
-	if(async_write_str(CMD_GEN, tosend))
+		rc=-1;
+	if(!rc && async_write_str(CMD_GEN, tosend))
 	{
 		logp("Error in async_write_str when sending incexc\n");
-		return -1;
+		rc=-1;
 	}
-	return 0;
+	if(tosend)
+		free(tosend);
+	return rc;
 }
 
 static int send_incexc_int(const char *pre, int myint)

--- a/src/list_client.c
+++ b/src/list_client.c
@@ -174,7 +174,7 @@ int do_list_client(struct config *conf, enum action act, int json)
 	int ret=0;
 	size_t slen=0;
 	char msg[512]="";
-	char scmd;
+	char scmd=0;
 	struct stat statp;
 	char *statbuf=NULL;
 	char ls[2048]="";
@@ -201,7 +201,7 @@ int do_list_client(struct config *conf, enum action act, int json)
 	// This should probably should use the sbuf stuff.
 	while(1)
 	{
-		char fcmd;
+		char fcmd=0;
 		size_t flen=0;
 		int64_t winattr=0;
 		int compression=-1;
@@ -292,7 +292,7 @@ int do_list_client(struct config *conf, enum action act, int json)
 		}
 		else if(cmd_is_link(fcmd)) // symlink or hardlink
 		{
-			char lcmd;
+			char lcmd=0;
 			size_t llen=0;
 			char *lname=NULL;
 			if(async_read(&lcmd, &lname, &llen)

--- a/src/msg.c
+++ b/src/msg.c
@@ -182,7 +182,7 @@ static int transfer_efs_in(BFILE *bfd, unsigned long long *rcvd, unsigned long l
 
 int transfer_gzfile_in(struct sbuf *sb, const char *path, BFILE *bfd, FILE *fp, unsigned long long *rcvd, unsigned long long *sent, const char *encpassword, int enccompressed, struct cntr *cntr, char **metadata)
 {
-	char cmd;
+	char cmd=0;
 	char *buf=NULL;
 	size_t len=0;
 	int quit=0;

--- a/src/restore_client.c
+++ b/src/restore_client.c
@@ -591,7 +591,7 @@ static int overwrite_ok(struct sbuf *sb, struct config *conf, BFILE *bfd, const 
 		// If we have file data and the destination is
 		// a fifo, it is OK to write to the fifo.
 		if((sb->cmd==CMD_FILE || sb->cmd==CMD_ENC_FILE)
-	  	  && S_ISFIFO(checkstat.st_mode))
+	  	  && S_ISFIFO(sb->statp.st_mode))
 			return 1;
 
 		// File path exists. Do not overwrite.

--- a/src/sbuf.c
+++ b/src/sbuf.c
@@ -84,7 +84,7 @@ static int do_sbuf_fill_from_net(struct sbuf *sb, struct cntr *cntr)
 	if((ars=async_read(&(sb->cmd), &(sb->path), &(sb->plen)))) return ars;
 	if(sbuf_is_link(sb))
 	{
-		char cmd;
+		char cmd=0;
 		if((ars=async_read(&cmd, &(sb->linkto), &(sb->llen))))
 				return ars;
 		if(!cmd_is_link(cmd))


### PR DESCRIPTION
The following command

```
valgrind --leak-check=full --track-origins=yes ./burp
```

is now almost clean - we still get a memory leak error in `SSL_connect` (`client.c:202`), and there's still reachable memory (allocated by OpenSSL) when `burp` exits. 

Note that among the many (harmless) uninitialized locals that valgrind reported, lurked a genuine bug in `restore_client.c` (`overwrite_ok` checked the wrong `stat` struct when considering a FIFO).

Server mode still needs to be checked, but it'll take a while.

Please review and pull.
