### PR TITLE
Update notify_script

### DIFF
--- a/configs/server/notify_script
+++ b/configs/server/notify_script
@@ -24,11 +24,9 @@ while [ "$#" -gt 0 ] ; do
 	case "$1" in
 		Subject:*)
 			w=""
-			[ -n "$warnings" -a "$warnings" != "0" ] \
-				&& w="($warnings warnings)"
 			h="$1"
 			h="${h//%c/$client}"
-			h="${h//%w/$w}"
+			h="${h//%w/$warnings}"
 			h="${h//%b/$brv}"
 			;;
 		*) h="$1"


### PR DESCRIPTION
Returns nothing. 
The script is called, but in the email there are no warnings of indicated. 

If we replace h="${h//%w/$w}" by h="${h//%w/$warnings}" finally gets what BURP returns, with one exception: 

BURP has another bug elsewhere. on a log with 600 warnings, it shows 0 in syslog when notify_script is called, look: 

"Running notify script: testclient /var/spool/burp/testclient /var/spool/burp/testclient/0000008 2014-07-15 23:00:02 restorelog restore 0 sendmail..." 

The problem of notify_script is set with this fix, but someone should fix the second bug in BURP correctly to get the real number of warnings in the email.
