### PR TITLE
Add quota feature

### DIFF
--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -218,6 +218,12 @@ When set to 0, delta differencing will not take place. That is, when a file chan
 \fBcompression=gzip[0-9]\fR
 Choose the level of gzip compression for files stored in backups. Setting 0 or gzip0 turns compression off. The default is gzip9. This option can be overridden by the client configuration files in clientconfdir on the server.
 .TP
+\fBhard_quota=[b/Kb/Mb/Gb]\fR
+Do not back up the client if the estimated size of all files is greater than the specified size. Example: 'hard_quota = 100Gb'. Set to 0 (the default) to have no limit.
+.TP
+\fBsoft_quota=[b/Kb/Mb/Gb]\fR
+A warning will be issued when the estimated size of all files is greater than the specified size and smaller than hard_quota. Example: 'soft_quota = 95Gb'. Set to 0 (the default) to have no warning.
+.TP
 \fBversion_warn=[0|1]\fR
 When this is on, which is the default, a warning will be issued when the client version does not match the server version. This option can be overridden by the client configuration files in clientconfdir on the server.
 .TP
@@ -602,6 +608,8 @@ Additionally, the following options can be overridden here for each client:
 \fBclient_can_verify\fR
 \fBrestore_client\fR
 \fBcompression\fR
+\fBhard_quota\fR
+\fBsoft_quota\fR
 \fBtimer_script\fR
 \fBtimer_arg\fR
 \fBnotify_success_script\fR

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -58,6 +58,7 @@ SVRSRCS =	acl.c \
 		msg.c \
 		prepend.c \
 		prog.c \
+		quota.c \
 		regexp.c \
 		restore_client.c \
 		restore_server.c \

--- a/src/backup_phase2_client.c
+++ b/src/backup_phase2_client.c
@@ -425,6 +425,7 @@ static int do_backup_phase2_client(struct config *conf, int resume, struct cntr 
 			else if(cmd==CMD_WARNING)
 			{
 				do_filecounter(cntr, cmd, 0);
+				logp("WARNING: %s\n",buf);
 				free(buf);
 				buf=NULL;
 			}

--- a/src/conf.c
+++ b/src/conf.c
@@ -201,6 +201,9 @@ void init_config(struct config *conf)
 	conf->restore_client=NULL;
 	conf->restore_path=NULL;
 	conf->orig_client=NULL;
+	
+	conf->hard_quota=0;
+	conf->soft_quota=0;
 
 	init_incexcs(conf);
 }
@@ -959,6 +962,16 @@ static int load_config_field_and_value(struct config *conf, const char *field, c
 		if(get_file_size(value, &(conf->max_file_size),
 			config_path, line)) return -1;
 	}
+	else if(!strcmp(field, "hard_quota"))
+	{
+		if(get_file_size(value, &(conf->hard_quota),
+			config_path, line)) return -1;
+	}
+	else if(!strcmp(field, "soft_quota"))
+	{
+		if(get_file_size(value, &(conf->soft_quota),
+			config_path, line)) return -1;
+	}
 	else
 	{
 		if(load_config_ints(conf, field, value))
@@ -1594,6 +1607,8 @@ int set_client_global_config(struct config *conf, struct config *cconf, const ch
 	cconf->compression=conf->compression;
 	cconf->version_warn=conf->version_warn;
 	cconf->resume_partial=conf->resume_partial;
+	cconf->hard_quota=conf->hard_quota;
+	cconf->soft_quota=conf->soft_quota;
 	cconf->notify_success_warnings_only=conf->notify_success_warnings_only;
 	cconf->notify_success_changes_only=conf->notify_success_changes_only;
 	cconf->server_script_post_run_on_fail=conf->server_script_post_run_on_fail;

--- a/src/conf.h
+++ b/src/conf.h
@@ -151,6 +151,8 @@ struct config
 	int compression;
 	int version_warn;
 	int resume_partial;
+	unsigned long hard_quota;
+	unsigned long soft_quota;
 
 	char *timer_script;
 	struct strlist **timer_arg;

--- a/src/quota.c
+++ b/src/quota.c
@@ -1,0 +1,33 @@
+#include "burp.h"
+#include "prog.h"
+#include "counter.h"
+#include "asyncio.h"
+#include "log.h"
+#include "quota.h"
+
+// Return O for OK, -1 if the estimated size is greater than hard_quota 
+int check_quota(struct config *conf, struct cntr *p1cntr)
+{
+	int ret=0;
+	// Print error if the estimated size is greater than hard_quota
+	if(conf->hard_quota != 0 && p1cntr->byte > conf->hard_quota)
+	{
+		logw(p1cntr, "Err: hard quota is reached");
+		logp("bytes estimated: %Lu%s\n", p1cntr->byte, bytes_to_human(p1cntr->byte));
+		logp("hard quota: %Lu%s\n", conf->hard_quota, bytes_to_human(conf->hard_quota));
+		ret=-1;
+	}
+	else
+	{
+		// Print warning if the estimated size is greater than soft_quota
+		if(conf->soft_quota != 0 && p1cntr->byte > conf->soft_quota)
+		{
+			logw(p1cntr, "soft quota is exceeded");
+			logp("bytes estimated: %Lu%s\n", p1cntr->byte, bytes_to_human(p1cntr->byte));
+			logp("soft quota: %Lu%s\n", conf->soft_quota, bytes_to_human(conf->soft_quota));
+		}  
+	}
+	
+	
+	return ret;
+}

--- a/src/quota.h
+++ b/src/quota.h
@@ -1,0 +1,6 @@
+#ifndef _QUOTA_H
+#define _QUOTA_H
+
+extern int check_quota(struct config *conf, struct cntr *p1cntr);
+
+#endif

--- a/src/server.c
+++ b/src/server.c
@@ -26,6 +26,7 @@
 #include "incexc_recv.h"
 #include "incexc_send.h"
 #include "ca_server.h"
+#include "quota.h"
 
 #include <netdb.h>
 #include <librsync.h>
@@ -472,6 +473,9 @@ static int do_backup_server(const char *basedir, const char *current, const char
 			logp("error in phase 1\n");
 			goto error;
 		}
+		
+		if(check_quota(cconf, p1cntr))
+			goto error;
 	}
 
 	// Open the previous (current) manifest.


### PR DESCRIPTION
Hi Graham,

Same work to next release of burp 1.4 :
This is the new patch to add the quota feature.
The soft_quota and hard_quota are checked on the server side and a warning message is displayed on the client if the hard quota is reached or if the soft quota is exceeded.
The information about the options are added to the man page.
This patch is a draft, i'm not sur that is the best implementation.

Best regards
