### PR TITLE
Replace c_rehash with a for loop calling openssl

### DIFF
--- a/configs/certs/CA/burp_ca
+++ b/configs/certs/CA/burp_ca
@@ -186,7 +186,8 @@ if [ "$sign" = "yes" ]; then
     exit 0
   fi
   mv ${dir}/newcerts/${serial}.pem ${dir}/certs/${serial}.pem
-  c_rehash ${dir}/certs
+  #rehash the certificates
+  for file in ${dir}/certs/*.pem; do ln -s -f $file ${dir}/certs/`openssl x509 -hash -noout -in $file`.0; done
 fi
 
 #revoke


### PR DESCRIPTION
Freebsd has no c_rehash installed by default. This for loop generates a hash link for every pem file in the certs directory.
