### PR TITLE
Fix xattr detection on OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1445,35 +1445,6 @@ if test x$support_xattr = xyes -o x$support_xattr = xauto; then
       fi
    fi
 
-   dnl
-   dnl If we failed to find *BSD support and the Linux or OSX implementation of xattr try the Solaris xattr implementation
-   dnl
-   if test $have_xattr = no; then
-      AC_CHECK_HEADER(sys/attr.h, [ AC_DEFINE(HAVE_SYS_ATTR_H,1,[Defines if your system have the sys/attr.h header file])] , )
-      AC_CHECK_HEADER(sys/nvpair.h, [ AC_DEFINE(HAVE_SYS_NVPAIR_H,1,[Defines if your system have the sys/nvpair.h header file])] , )
-      AC_CHECK_HEADER(attr.h, [ AC_DEFINE(HAVE_ATTR_H,1,[Defines if your system have the attr.h header file])] , )
-
-      AC_CHECK_FUNCS(openat fstatat unlinkat fchownat futimesat,
-	 [
-	     have_xattr=yes
-	     AC_DEFINE([HAVE_OPENAT],1,[Define to 1 if you have the 'openat' function.])
-	     AC_DEFINE([HAVE_FSTATAT],1,[Define to 1 if you have the 'fstatat' function.])
-	     AC_DEFINE([HAVE_UNLINKAT],1,[Define to 1 if you have the 'unlinkat' function.])
-	     AC_DEFINE([HAVE_FCHOWNAT],1,[Define to 1 if you have the 'fchownat' function.])
-	     AC_DEFINE([HAVE_FUTIMESAT],1,[Define to 1 if you have the 'futimesat' function.])
-	 ]
-      )
-
-      if test $have_xattr = yes; then
-	 AC_CHECK_LIB(nvpair, nvlist_next_nvpair,
-	    [
-		AC_DEFINE([HAVE_NVLIST_NEXT_NVPAIR],1,[Define to 1 if you have the 'nvlist_next_nvpair' function.])
-		FDLIBS="-lnvpair $FDLIBS"
-	    ]
-	 )
-      fi
-   fi
-
    if test x$support_xattr = xyes -a $have_xattr != yes; then
       AC_MSG_ERROR([xattr support explicitly enabled but no supported xattr implementation found, 
   please either load the xattr libraries or rerun configure without --enable-xattr])

--- a/src/client/acl.c
+++ b/src/client/acl.c
@@ -10,7 +10,6 @@
 #ifdef HAVE_ACL
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS)
 #include "sys/acl.h"
 
@@ -25,7 +24,6 @@ static int acl_is_trivial(acl_t acl)
 {
 #if defined(HAVE_LINUX_OS) \
  || defined(HAVE_FREEBSD_OS) \
- || defined(HAVE_OPENBSD_OS) \
  || defined(HAVE_NETBSD_OS)
 	/*
 	 * acl is trivial if it has only the following entries:

--- a/src/client/acl.h
+++ b/src/client/acl.h
@@ -4,7 +4,6 @@
 #ifdef HAVE_ACL
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS)
 extern int has_acl(const char *path, enum cmd cmd);
 extern int get_acl(struct asfd *asfd, struct sbuf *sb,

--- a/src/client/extrameta.c
+++ b/src/client/extrameta.c
@@ -19,7 +19,6 @@ int has_extrameta(const char *path, enum cmd cmd, enum protocol protocol,
 	if(protocol==PROTO_2) return 0;
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS)
 
 #ifdef HAVE_ACL
@@ -28,7 +27,6 @@ int has_extrameta(const char *path, enum cmd cmd, enum protocol protocol,
 #endif
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS) || \
     defined(HAVE_DARWIN_OS)
 #ifdef HAVE_XATTR
@@ -52,7 +50,6 @@ int get_extrameta(struct asfd *asfd,
 	// some entries if acls were set.
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS)
 #ifdef HAVE_ACL
 	if(get_acl(asfd, sb, extrameta, elen, cntr)) return -1;
@@ -60,7 +57,6 @@ int get_extrameta(struct asfd *asfd,
 #endif
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS) || \
     defined(HAVE_DARWIN_OS)
 #ifdef HAVE_XATTR
@@ -115,7 +111,6 @@ int set_extrameta(struct asfd *asfd,
 #endif
 #if defined(HAVE_LINUX_OS) || \
     defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS)
 #ifdef HAVE_ACL
 			case META_ACCESS_ACL:
@@ -138,7 +133,6 @@ int set_extrameta(struct asfd *asfd,
 #endif
 #endif
 #if defined(HAVE_FREEBSD_OS) || \
-    defined(HAVE_OPENBSD_OS) || \
     defined(HAVE_NETBSD_OS)
 #ifdef HAVE_XATTR
 			case META_XATTR_BSD:

--- a/src/client/xattr.c
+++ b/src/client/xattr.c
@@ -12,7 +12,6 @@
 #if defined(HAVE_LINUX_OS) \
  || defined(HAVE_FREEBSD_OS) \
  || defined(HAVE_NETBSD_OS) \
- || defined(HAVE_OPENBSD_OS) \
  || defined(HAVE_DARWIN_OS)
 
 static char *get_next_str(struct asfd *asfd, char **data, size_t *l,
@@ -299,8 +298,7 @@ int set_xattr(struct asfd *asfd, const char *path,
 #endif // HAVE_LINUX_OS
 
 #if defined(HAVE_FREEBSD_OS) \
- || defined(HAVE_NETBSD_OS) \
- || defined(HAVE_OPENBSD_OS)
+ || defined(HAVE_NETBSD_OS)
 
 
 #include <sys/extattr.h>
@@ -583,6 +581,6 @@ int set_xattr(struct asfd *asfd, const char *path,
 	return -1;
 }
 
-#endif // HAVE_FREE/NET/OPENBSD_OS
+#endif // HAVE_FREE/NETBSD_OS
 
 #endif // HAVE_XATTR

--- a/src/client/xattr.h
+++ b/src/client/xattr.h
@@ -4,7 +4,6 @@
 #ifdef HAVE_XATTR
 #if defined(HAVE_LINUX_OS) \
  || defined(HAVE_FREEBSD_OS) \
- || defined(HAVE_OPENBSD_OS) \
  || defined(HAVE_NETBSD_OS) \
  || defined(HAVE_DARWIN_OS)
 extern int has_xattr(const char *path);


### PR DESCRIPTION
OpenBSD doesn't have extended attributes
but we failed to detect that.

This is because the last xattr check, which checked for the Solaris
implementation, decided that we had xattr support when one of
the functions openat, fstatat, unlinkat, fchownat or futimesat was found.

The simple solution is to remove the Solaris check, since we don't implement
xattr support on Solaris anyway.

Fixes #312