### PR TITLE
Only test xattrs when supported

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -282,7 +282,6 @@ runner_SOURCES = \
 	utest/client/test_auth.c \
 	utest/client/test_find.c \
 	utest/client/test_restore.c \
-	utest/client/test_xattr.c \
 	utest/server/monitor/test_browse.c \
 	utest/server/monitor/test_cstat.c \
 	utest/server/monitor/test_json_output.c \
@@ -307,6 +306,10 @@ runner_SOURCES = \
 	utest/server/test_resume.c \
 	utest/server/test_restore.c \
 	utest/server/test_sdirs.c
+
+if WITH_XATTR
+runner_SOURCES+= utest/client/test_xattr.c
+endif
 
 runner_SOURCES+= $(burp_SOURCES)
 

--- a/configure.ac
+++ b/configure.ac
@@ -416,6 +416,8 @@ if test "$have_xattr" = "yes"; then
   AC_DEFINE([HAVE_XATTR], [1], [Extended Attributes support])
 fi
 
+AM_CONDITIONAL([WITH_XATTR], [test "$have_xattr" = "yes"])
+
 dnl set sysconfdir to /etc/burp unless specified otherwise
 if test "$prefix" = "NONE" && test "$sysconfdir" = '${prefix}/etc'; then
   sysconfdir='/etc/burp'

--- a/utest/main.c
+++ b/utest/main.c
@@ -19,7 +19,6 @@ int main(void)
 	srunner_add_suite(sr, suite_client_protocol1_backup_phase2());
 	srunner_add_suite(sr, suite_client_protocol2_backup_phase2());
 	srunner_add_suite(sr, suite_client_restore());
-	srunner_add_suite(sr, suite_client_xattr());
 	srunner_add_suite(sr, suite_cmd());
 	srunner_add_suite(sr, suite_conf());
 	srunner_add_suite(sr, suite_conffile());
@@ -59,7 +58,9 @@ int main(void)
 	srunner_add_suite(sr, suite_server_resume());
 	srunner_add_suite(sr, suite_server_sdirs());
 	srunner_add_suite(sr, suite_slist());
-
+#ifdef HAVE_XATTR
+	srunner_add_suite(sr, suite_client_xattr());
+#endif
 	srunner_run_all(sr, CK_NORMAL);
 	number_failed = srunner_ntests_failed(sr);
 	srunner_free(sr);


### PR DESCRIPTION
This let's the runner compile on OpenBSD