### PR TITLE
Fix 'make distcheck'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,9 +8,9 @@ EXTRA_DIST = \
 	android/build-script-android \
 	android/burp_ca \
 	android/README \
-	configs/burp.conf.in \
-	configs/burp-server.conf.in \
-	configs/CA.cnf.in \
+	configs/client/burp.conf.in \
+	configs/server/burp.conf.in \
+	configs/certs/CA/CA.cnf.in \
 	debian \
 	freebsd \
 	rhel \


### PR DESCRIPTION
5274f32fa82c1c112de6fd12185411b078155c26 removed the
configs from dist_sysconf_DATA, which also removed them
from dist. Include the configs in EXTRA_DIST to fix this.