### PR TITLE
Use AC_CHECK_TYPES to check for struct utimbuf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,25 +74,12 @@ AC_SYS_LARGEFILE
 dnl --------------------------------------------------------------------------
 dnl Check for utimebuf structure
 dnl --------------------------------------------------------------------------
-AC_CACHE_CHECK([for struct utimebuf], [ba_cv_header_utime_h], [
-  AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM(
-      [[
-        #include <sys/types.h>
-        #include <utime.h>
-      ]],
-      [[
-        struct utimbuf foo;
-      ]]
-    )],
-    [ba_cv_header_utime_h=yes],
-    [ba_cv_header_utime_h=no]
-  )
-])
-
-if test "$ba_cv_header_utime_h" = "yes"; then
-  AC_DEFINE([HAVE_UTIME_H], [1], [Set to 1 if we have struct utimebuf])
-fi
+AC_CHECK_TYPES([struct utimbuf], [], [],
+  [[
+    #include <sys/types.h>
+    #include <utime.h>
+  ]]
+)
 
 dnl --------------------------------------------------------------------------
 dnl Check for typeof()

--- a/src/burp.h
+++ b/src/burp.h
@@ -86,7 +86,7 @@
 	#include "winhost.h"
 #endif
 
-#if HAVE_UTIME_H
+#if HAVE_STRUCT_UTIMBUF
 	#include <utime.h>
 #else
 	struct utimbuf {

--- a/src/client/find.h
+++ b/src/client/find.h
@@ -42,15 +42,6 @@
 
 #include <sys/file.h>
 #include <sys/param.h>
-#if HAVE_UTIME_H
-#include <utime.h>
-#else
-struct utimbuf
-{
-	long actime;
-	long modtime;
-};
-#endif
 
 #define MODE_RALL (S_IRUSR|S_IRGRP|S_IROTH)
 

--- a/src/win32/compat/mingwconfig.h
+++ b/src/win32/compat/mingwconfig.h
@@ -23,8 +23,8 @@
 /* Define if you have GCC */
 #define HAVE_GCC 1
 
-/* Define to 1 if utime.h exists and declares struct utimbuf.  */
-#define HAVE_UTIME_H 1
+/* Define to 1 if struct utimbuf exists.  */
+#define HAVE_STRUCT_UTIMBUF 1
 
 /* Data types */
 #define HAVE_U_INT 1


### PR DESCRIPTION
And fix a typo in the proces.

Remove the compat type from find.h since all files which include find.h first include burp.h.