### PR TITLE
Fix Timestamp in logfiles

### DIFF
--- a/src/cntr.c
+++ b/src/cntr.c
@@ -153,7 +153,7 @@ int cntr_init(struct cntr *cntr, const char *cname)
 	)
 		return -1;
 
-	cntr->ent[(uint8_t)CMD_TIMESTAMP]->count=(uint64_t)time(NULL);
+	cntr->ent[(uint8_t)CMD_TIMESTAMP]->count=((uint64_t)time(NULL) - timezone);
 
 	cntr->str_max_len=calc_max_str_len(cntr, cname);
 	if(!(cntr->str=(char *)calloc_w(1, cntr->str_max_len, __func__))
@@ -497,7 +497,7 @@ void cntr_print(struct cntr *cntr, enum action act)
 	time_t now;
 	time_t start;
 	if(!cntr) return;
-	now=time(NULL);
+	now=time(NULL) - timezone;
 	start=(time_t)cntr->ent[(uint8_t)CMD_TIMESTAMP]->count;
 	cntr->ent[(uint8_t)CMD_TIMESTAMP_END]->count=(uint64_t)now;
 
@@ -547,7 +547,7 @@ int cntr_stats_to_file(struct cntr *cntr,
 	if(!cntr)
 		return 0;
 	cntr->ent[(uint8_t)CMD_TIMESTAMP_END]->count
-		=(uint64_t)time(NULL);
+		=((uint64_t)time(NULL) - timezone);
 
 	if(act==ACTION_BACKUP
 	  ||  act==ACTION_BACKUP_TIMED)
@@ -635,7 +635,7 @@ size_t cntr_to_str(struct cntr *cntr, const char *path)
 	struct cntr_ent *e=NULL;
 	char *str=cntr->str;
 
-	cntr->ent[(uint8_t)CMD_TIMESTAMP_END]->count=time(NULL);
+	cntr->ent[(uint8_t)CMD_TIMESTAMP_END]->count=(time(NULL) - timezone);
 
 	snprintf(str, cntr->str_max_len-1, "%s\t%d\t%d\t",
 		cntr->cname, CNTR_VERSION, cntr->cntr_status);

--- a/src/server/monitor/json_output.c
+++ b/src/server/monitor/json_output.c
@@ -200,7 +200,7 @@ static int do_counters(struct cntr *cntr)
 	struct cntr_ent *e;
 
 #ifndef UTEST
-	cntr->ent[(uint8_t)CMD_TIMESTAMP_END]->count=(uint64_t)time(NULL);
+	cntr->ent[(uint8_t)CMD_TIMESTAMP_END]->count=((uint64_t)time(NULL) - timezone);
 #endif
 	if(yajl_gen_str_w("counters")
 	  || yajl_array_open_w()) return -1;


### PR DESCRIPTION
Hi there

I noticed the times in logfiles are off in version 2 (they were correct back in version 1). Since that had some impact on our monitoring I did a quick-and-dirty fix. Works fine under linux, but was not tested on other OS.

Regards