### PR TITLE
Terminate build on first error with non-zero exit code

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,7 +40,7 @@ all: Makefile
 	@for I in ${all_subdirs}; \
 	  do (cd $$I; echo "==>Entering directory `pwd`"; \
 	      $(MAKE) $@ || (echo ""; echo ""; echo "  ====== Error in `pwd` ======"; \
-			    echo ""; echo "";)); \
+			    echo ""; echo ""; exit 1;)) || exit 1; \
 	done
 
 depend:


### PR DESCRIPTION
Because exit status of sub call to make gets lost, make proceeds to
next target even on failure and eventually make returns success code for
failure. Return exit code 1 from sub shells in case of failure.