### PR TITLE
Fix build on OSX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -94,6 +94,10 @@ dist_script_SCRIPTS = \
 
 vss_strip_SOURCES = src/server/protocol1/vss_strip.c
 
+vss_strip_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	$(OPENSSL_INC)
+
 burp_LDADD = \
 	$(ACL_LIBS) \
 	$(CRYPT_LIBS) \


### PR DESCRIPTION
ruben@wodan: burp (master=)$ make check
  CC       src/server/protocol1/vss_strip.o
In file included from src/server/protocol1/vss_strip.c:1:
src/server/protocol1/../../burp.h:69:10: fatal error: 'openssl/ssl.h'
file not found
         ^
1 error generated.
make: *** [src/server/protocol1/vss_strip.o] Error 1

vss_strip.c includes burp.h, which includes openssl/ssl.h

Since openssl/ssl.h is not in the standard include path,
we need to add it to vss_strips CPPFLAGS.