### PR TITLE
Add setsockopt for keepalive activation (tested under Linux only)

### DIFF
--- a/src/handy.c
+++ b/src/handy.c
@@ -270,6 +270,7 @@ int init_client_socket(const char *host, const char *port)
 {
 	int rfd=-1;
 	int gai_ret;
+	int keepalive = 1;
 	struct addrinfo hints;
 	struct addrinfo *result;
 	struct addrinfo *rp;
@@ -290,6 +291,7 @@ int init_client_socket(const char *host, const char *port)
 	{
 		rfd=socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
 		if(rfd<0) continue;
+		setsockopt(rfd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
 		if(connect(rfd, rp->ai_addr, rp->ai_addrlen) != -1) break;
 		close_fd(&rfd);
 	}

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -80,6 +80,7 @@ static void chld_check_for_exiting(struct async *mainas)
 static int init_listen_socket(const char *address, const char *port, int *fds)
 {
 	int i;
+	int keepalive=1;
 	int gai_ret;
 	struct addrinfo hints;
 	struct addrinfo *rp=NULL;
@@ -111,6 +112,7 @@ static int init_listen_socket(const char *address, const char *port, int *fds)
 				port, strerror(errno));
 			continue;
 		}
+		setsockopt(fds[i], SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
 #ifdef HAVE_IPV6
 		if(rp->ai_family==AF_INET6)
 		{


### PR DESCRIPTION
When clients crash without closing connection correctly we had stuck client processes hanging around and blocking (since pid and locks were found). Thus new clients would'nt start and backup was completely stuck.
Using these options we make sure crashed clients are detected.