### PR TITLE
Ignore "child status pipe" in network_timeout logic

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -151,6 +151,7 @@ static int async_io(struct async *as, int doread)
 			if((as->setsec || as->setusec)
 			  && asfd->fdtype!=ASFD_FD_SERVER_LISTEN_MAIN
 			  && asfd->fdtype!=ASFD_FD_SERVER_LISTEN_STATUS
+			  && asfd->fdtype!=ASFD_FD_CHILD_PIPE_WRITE
 			  && as->now-as->last_time>0
 			  && as->now-as->last_time>0
 			  && asfd->max_network_timeout>0


### PR DESCRIPTION
If backups are long enough and transfer big chunks of data without a message added to the status log, the child status pipe would get closed because of timeout. We remove it from the tested fstypes so the backup can continue as long as necessary even if no line is printed on log for more that network_timeout seconds.
To test it more quickly, add a low network_timeout value in client conf file (on server) and start a backup ; we received this kind of messages :

2016-01-26 09:20:00: burp[27815] Client version: 2.0.30
2016-01-26 09:20:00: burp[27815] Protocol: 2
2016-01-26 09:20:00: burp[27815] Begin phase1 (file system scan)
2016-01-26 09:22:30: burp[27815] End phase1 (file system scan)
2016-01-26 09:22:30: burp[27815] forked champ chooser pid 28544
2016-01-26 09:22:33: burp[27815] Connected to champ chooser.
2016-01-26 09:22:33: burp[27815] Phase 2 begin (recv backup data)
2016-01-26 11:22:41: burp[27815] child status pipe: no activity for 7200 seconds.
2016-01-26 11:22:41: burp[27815] error from as->read_write in backup_phase2_server_protocol2
2016-01-26 11:22:41: burp[27815] End backup
2016-01-26 11:22:45: burp[27815] error in backup phase 2
2016-01-26 11:41:54: burp[12346] Found interrupted backup.
2016-01-26 11:41:54: burp[12346] Will resume on the next backup request.