### PR TITLE
Allow for setting test verbosity from environment

### DIFF
--- a/utest/main.c
+++ b/utest/main.c
@@ -62,7 +62,7 @@ int main(void)
 	srunner_add_suite(sr, suite_server_sdirs());
 	srunner_add_suite(sr, suite_slist());
 
-	srunner_run_all(sr, CK_NORMAL);
+	srunner_run_all(sr, CK_ENV);
 	number_failed = srunner_ntests_failed(sr);
 	srunner_free(sr);
 	return number_failed == 0 ? EXIT_SUCCESS : EXIT_FAILURE;


### PR DESCRIPTION
The default for CK_ENV is 'normal'.
This permits overriding it via the environment, i.e.
CK_VERBOSITY=verbose ./runner