### PR TITLE
Fix test_fzp_read on solaris

### DIFF
--- a/utest/test_fzp.c
+++ b/utest/test_fzp.c
@@ -48,7 +48,8 @@ static void read_checks(
 
 	fail_unless((fzp=open_func(file, "rb"))!=NULL);
 	fail_unless(fzp_read(fzp, buf, d->want)==(int)d->got);
-	fail_unless((d->want>d->got) == fzp_eof(fzp));
+	if (d->want > d->got)
+		fail_unless(fzp_eof(fzp));
 	fail_unless(!fzp_close(&fzp));
 	fail_unless(fzp==NULL);
 


### PR DESCRIPTION
Fixes:
utest/test_fzp.c:51:F:Core:test_fzp_read:0: Assertion '(d->want>d->got) == fzp_eof(fzp)' failed