### PR TITLE
Set timezone to UTC before calling mktime

### DIFF
--- a/src/server/monitor/json_output.c
+++ b/src/server/monitor/json_output.c
@@ -97,7 +97,7 @@ static time_t my_timegm(struct tm *tm)
 		if(!(tz=strdup_w(tz, __func__)))
 			return -1;
 	}
-	setenv("TZ", "", 1);
+	setenv("TZ", "UTC0", 1);
 	tzset();
 	ret=mktime(tm);
 	if(tz)


### PR DESCRIPTION
If you set an empty TZ, mktime uses the system
timezone on Solaris.

Fixes test_json_matching_output