### PR TITLE
Fix a warning with older automake versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,7 @@ dnl Check for compiler.
 dnl ------------------------------------------------------
 
 AC_PROG_CXX
+AM_PROG_CC_C_O
 
 dnl -------------------------------------------------------
 dnl Check for programs.


### PR DESCRIPTION
Makefile.am:118: compiling `src/alloc.c' in subdir requires
`AM_PROG_CC_C_O' in `configure.ac'