### PR TITLE
Fix base64 decoding test on NetBSD

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -118,7 +118,7 @@ int from_base64(int64_t *value, const char *where)
 	/* Construct value */
 	for(char c=where[i]; c && c!=' '; c=where[++i])
 	{
-		if(!isalnum(c) && c!='+' && c!='/')
+		if(!isalnum((unsigned char)c) && c!='+' && c!='/')
 			continue;
 		val<<=6;
 		val+=base64_map[(uint8_t)c];


### PR DESCRIPTION
From isalnum(3):
The argument to isalnum() must be EOF or representable as an unsigned
     char; otherwise, the behavior is undefined.