### PR TITLE
Fix dindex filename in protocol 2 phase 4 regenerate client index

### DIFF
--- a/src/server/protocol2/backup_phase4.c
+++ b/src/server/protocol2/backup_phase4.c
@@ -554,7 +554,7 @@ int regenerate_client_dindex(struct sdirs *sdirs)
 
 	for(bu=bu_list; bu; bu=bu->next)
 	{
-		snprintf(tmp, sizeof(tmp), "%08lu", bu->index-1);
+		snprintf(tmp, sizeof(tmp), "%08"PRIX64, bu->index-1);
 		if(!(newpath=prepend_s(sdirs->dindex, tmp))
 		  || !(oldpath=prepend_s(bu->path, "manifest/dfiles")))
 			goto end;


### PR DESCRIPTION
Hello,

Got errors in log 2 last nights :
`Feb  1 01:23:54 burp[30837]: could not open /var/backup/<PATH>/clients/<CLIENT>/dindex/0000000A: No such file or directory`


```
# ls /var/backup/<PATH>/clients/<CLIENT>/dindex/
00000000  00000001  00000002  00000003
00000004  00000005  00000006  00000007
00000008  00000009  00000010  00000011
```

It seems "regenerare_client_dindex" was using filenames with decimals instead of hex ; I have looked through the code and found only this one.
(I renamed the actual files and will see if all goes well again tomorrow)

Obviously if you want to make a test for this one you have to make at least 10 backups :smile:, which may be a bit long test.