### PR TITLE
Support additional algorithms for passwd option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+  * Add support for glibc's additional algorithms in crypt(3)-style passwords
+    ("passwd" configuration option)
+
 2016-01-31 Changes in burp-2.0.32:
   * Tweak README install instructions.
   * Fix ncurses output option.

--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -12,15 +12,12 @@
 static int check_passwd(const char *passwd, const char *plain_text)
 {
 #ifdef HAVE_CRYPT
-	char salt[3];
-
-	if(!plain_text || !passwd || strlen(passwd)!=13)
+	if(!plain_text || !passwd || strlen(passwd) < 13)
 		return 0;
 
-	salt[0]=passwd[0];
-	salt[1]=passwd[1];
-	salt[2]=0;
-	return !strcmp(crypt(plain_text, salt), passwd);
+	const char *encrypted = crypt(plain_text, passwd);
+
+	return encrypted && !strcmp(encrypted, passwd);
 #endif // HAVE_CRYPT
 	logp("Server compiled without crypt support - cannot use passwd option\n");
 	return -1;


### PR DESCRIPTION
Historically crypt(3) has only supported the DES algorithm. glibc's
implementation supports additional algorithms such as SHA-256, SHA-512
and, depending on the distribution, Blowfish. These are significantly
stronger than DES.

The function calling crypt(3), check_passwd, had a hardcoded length
check and assumed DES-encrypted passwords. Support for the glibc
extension can be added by passing the encrypted/hashed password directly
as the salt instead of extracting the first two characters. Other
implementations will continue to behave as-is.

This change also fixes a NULL-pointer dereference which would occur when
the crypt(3) function failed.