### PR TITLE
Fix compatibility for restore from proto1 only servers (ie. burp 1.4.x)

### DIFF
--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -600,8 +600,8 @@ int do_restore_client(struct asfd *asfd,
 
 	logf("\n");
 
-//	if(get_int(confs[OPT_SEND_CLIENT_CNTR]) && cntr_recv(confs))
-//		goto error;
+	if(get_int(confs[OPT_SEND_CLIENT_CNTR]) && cntr_recv(asfd, confs))
+		goto error;
 
 	if(!(sb=sbuf_alloc(protocol))
 	  || (protocol==PROTO_2 && !(blk=blk_alloc())))
@@ -620,7 +620,7 @@ int do_restore_client(struct asfd *asfd,
 		{
 			case 0: break;
 			case 1: if(asfd->write_str(asfd, CMD_GEN,
-				"restoreend_ok")) goto error;
+				"restoreend ok")) goto error;
 				goto end; // It was OK.
 			default:
 			case -1: goto error;

--- a/src/server/restore.c
+++ b/src/server/restore.c
@@ -28,7 +28,7 @@
 static enum asl_ret restore_end_func(struct asfd *asfd,
 	struct conf **confs, void *param)
 {
-	if(!strcmp(asfd->rbuf->buf, "restoreend_ok"))
+	if(!strcmp(asfd->rbuf->buf, "restoreend ok"))
 		return ASL_END_OK;
 	iobuf_log_unexpected(asfd->rbuf, __func__);
 	return ASL_END_ERROR;


### PR DESCRIPTION
 - read counters if expected (though the code seems to ignore them in cntr.c for now)
 - fix "restoreend ok" command to be the same as proto1 servers (with space instead of underscore)

Just to add a little bit more than my commit message :smile: I had "unexpected command in parse_cmd c:[CLIENTNAME] [COUNTERS]" error on client when trying to restore, which led my to this code path. It seems counters are not completely revamped for now but if they are not read (and discarded) the do_restore function then find a CMD_GEN with unexpected data (another possibility would be to disable :counters: feature advertising but it may be more difficult later to test when re-implemented)