### PR TITLE
Add protocol in status monitor

### DIFF
--- a/src/server/monitor/json_output.c
+++ b/src/server/monitor/json_output.c
@@ -353,6 +353,8 @@ static int json_send_client_start(struct asfd *asfd, struct cstat *cstat)
 		return -1;
 	if(yajl_gen_str_pair_w("run_status", run_status))
 		return -1;
+	if(yajl_gen_int_pair_w("protocol", cstat->protocol))
+		return -1;
 	if(cstat->run_status==RUN_STATUS_RUNNING)
 	{
 		if(yajl_gen_str_pair_w("phase",


### PR DESCRIPTION
Related to #410 

Here is a little patch to add the protocol in the status monitor output.
I don't lnow what are the implications on your test suite though.