### PR TITLE
Feature server can override include

### DIFF
--- a/configs/client/burp.conf.in
+++ b/configs/client/burp.conf.in
@@ -32,6 +32,10 @@ progress_counter = 1
 # initiate a restore.
 server_can_restore = 0
 
+# Set server_can_override_includes to 0 if you do not want the server to be able
+# to override the local include/exclude list. Defaults is 1.
+# server_can_override_includes = 1
+
 # Set an encryption password if you do not trust the server with your data.
 # Note that this will mean that network deltas will not be possible. Each time
 # a file changes, the whole file will be transferred on the next backup.

--- a/configs/client/burp.conf.in
+++ b/configs/client/burp.conf.in
@@ -32,8 +32,8 @@ progress_counter = 1
 # initiate a restore.
 server_can_restore = 0
 
-# Set server_can_override_includes to 0 if you do not want the server to be able
-# to override the local include/exclude list. Defaults is 1.
+# Set server_can_override_includes to 0 if you do not want the server to be
+# able to override the local include/exclude list. The default is 1.
 # server_can_override_includes = 1
 
 # Set an encryption password if you do not trust the server with your data.

--- a/docs/security-models.txt
+++ b/docs/security-models.txt
@@ -23,6 +23,9 @@ You are a client, and you don't trust the server.
    * You must not set the autoupgrade options in the client burp.conf.
    * You must set 'server_can_restore=0' in the client burp.conf to prevent
      server initiated restores.
+   * You must set 'server_can_override_includes=0' in the client burp.conf to
+     prevent the server from being able to backup files you do not want it to
+     access.
 
 Untrustworthy users
 -------------------

--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -521,6 +521,9 @@ Allowed SSL ciphers. See openssl ciphers for details.
 \fBserver_can_restore=[0|1]\fR
 To prevent the server from initiating restores, set this to 0. The default is 1.
 .TP
+\fBserver_can_override_includes=[0|1]\fR
+To prevent the server from behing able to override your local include/exclude list, set this to 0. The default is 1.
+.TP
 \fBencryption_password=[password]\fR
 Set this to enable client side file Blowfish encryption. If you do not want encryption, leave this field out of your config file. \fBIMPORTANT:\fR Configuring this renders delta differencing pointless, since the smallest real change to a file will make the whole file look different. Therefore, activating this option turns off delta differencing so that whenever a client file changes, the whole new file will be uploaded on the next backup. \fBALSO IMPORTANT:\fR If you manage to lose your encryption password, you will not be able to unencrypt your files. You should therefore think about having a copy of the encryption password somewhere off-box, in case of your client hard disk failing. \fBFINALLY:\fR If you change your encryption password, you will end up with a mixture of files on the server with different encryption and it may become tricky to restore more than one file at a time. For this reason, if you change your encryption password, you may want to start a fresh chain of backups (by moving the original set aside, for example). Burp will cope fine with turning the same encryption password on and off between backups, and will restore a backup of mixed encrypted and unencrypted files without a problem.
 .TP

--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -522,7 +522,7 @@ Allowed SSL ciphers. See openssl ciphers for details.
 To prevent the server from initiating restores, set this to 0. The default is 1.
 .TP
 \fBserver_can_override_includes=[0|1]\fR
-To prevent the server from behing able to override your local include/exclude list, set this to 0. The default is 1.
+To prevent the server from being able to override your local include/exclude list, set this to 0. The default is 1.
 .TP
 \fBencryption_password=[password]\fR
 Set this to enable client side file Blowfish encryption. If you do not want encryption, leave this field out of your config file. \fBIMPORTANT:\fR Configuring this renders delta differencing pointless, since the smallest real change to a file will make the whole file look different. Therefore, activating this option turns off delta differencing so that whenever a client file changes, the whole new file will be uploaded on the next backup. \fBALSO IMPORTANT:\fR If you manage to lose your encryption password, you will not be able to unencrypt your files. You should therefore think about having a copy of the encryption password somewhere off-box, in case of your client hard disk failing. \fBFINALLY:\fR If you change your encryption password, you will end up with a mixture of files on the server with different encryption and it may become tricky to restore more than one file at a time. For this reason, if you change your encryption password, you may want to start a fresh chain of backups (by moving the original set aside, for example). Burp will cope fine with turning the same encryption password on and off between backups, and will restore a backup of mixed encrypted and unencrypted files without a problem.

--- a/src/client/extra_comms.c
+++ b/src/client/extra_comms.c
@@ -125,10 +125,18 @@ int extra_comms(struct async *as, struct conf **confs,
 		if(!*incexc && server_supports(feat, ":sincexc:"))
 		{
 			logp("Server is setting includes/excludes.\n");
-			if(incexc_recv_client(asfd, incexc, confs))
-				goto end;
-			if(*incexc && conf_parse_incexcs_buf(confs,
-				*incexc)) goto end;
+			if(get_int(confs[OPT_SERVER_OVERRIDE_INCLUDES]))
+			{
+				logp("Client accepts.\n");
+				if(incexc_recv_client(asfd, incexc, confs))
+					goto end;
+				if(*incexc && conf_parse_incexcs_buf(confs,
+					*incexc)) goto end;
+			}
+			else
+			{
+				logp("Client configuration says no\n");
+			}
 		}
 	}
 

--- a/src/client/extra_comms.c
+++ b/src/client/extra_comms.c
@@ -125,7 +125,7 @@ int extra_comms(struct async *as, struct conf **confs,
 		if(!*incexc && server_supports(feat, ":sincexc:"))
 		{
 			logp("Server is setting includes/excludes.\n");
-			if(get_int(confs[OPT_SERVER_OVERRIDE_INCLUDES]))
+			if(get_int(confs[OPT_SERVER_CAN_OVERRIDE_INCLUDES]))
 			{
 				logp("Client accepts.\n");
 				if(incexc_recv_client(asfd, incexc, confs))

--- a/src/conf.c
+++ b/src/conf.c
@@ -485,6 +485,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "ca_csr_dir");
 	case OPT_RANDOMISE:
 	  return sc_int(c[o], 0, 0, "randomise");
+	case OPT_SERVER_OVERRIDE_INCLUDES:
+	  return sc_int(c[o], 1, 0, "server_can_override_includes");
 	case OPT_BACKUP:
 	  return sc_str(c[o], 0, CONF_FLAG_INCEXC_RESTORE, "backup");
 	case OPT_BACKUP2:

--- a/src/conf.c
+++ b/src/conf.c
@@ -485,7 +485,7 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "ca_csr_dir");
 	case OPT_RANDOMISE:
 	  return sc_int(c[o], 0, 0, "randomise");
-	case OPT_SERVER_OVERRIDE_INCLUDES:
+	case OPT_SERVER_CAN_OVERRIDE_INCLUDES:
 	  return sc_int(c[o], 1, 0, "server_can_override_includes");
 	case OPT_BACKUP:
 	  return sc_str(c[o], 0, CONF_FLAG_INCEXC_RESTORE, "backup");

--- a/src/conf.h
+++ b/src/conf.h
@@ -137,6 +137,7 @@ enum conf_opt
 	OPT_AUTOUPGRADE_DIR, // also a server option
 	OPT_CA_CSR_DIR,
 	OPT_RANDOMISE,
+	OPT_SERVER_OVERRIDE_INCLUDES,
 
 	// This block of client stuff is all to do with what files to backup.
 	OPT_STARTDIR,

--- a/src/conf.h
+++ b/src/conf.h
@@ -137,7 +137,7 @@ enum conf_opt
 	OPT_AUTOUPGRADE_DIR, // also a server option
 	OPT_CA_CSR_DIR,
 	OPT_RANDOMISE,
-	OPT_SERVER_OVERRIDE_INCLUDES,
+	OPT_SERVER_CAN_OVERRIDE_INCLUDES,
 
 	// This block of client stuff is all to do with what files to backup.
 	OPT_STARTDIR,

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -120,6 +120,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_CLIENT_CAN_RESTORE:
 		case OPT_CLIENT_CAN_VERIFY:
 		case OPT_SERVER_CAN_RESTORE:
+		case OPT_SERVER_CAN_OVERRIDE_INCLUDES:
 		case OPT_B_SCRIPT_RESERVED_ARGS:
 		case OPT_R_SCRIPT_RESERVED_ARGS:
 		case OPT_ACL:


### PR DESCRIPTION
This pull request addresses the #413 feature request.

The default behavior of the burp client remains unchanged unless you set `server_can_override_includes` to 0.