### PR TITLE
Fix champ_chooser lock to try until lock_tries_max instead of 10 seconds

### DIFF
--- a/src/server/protocol2/champ_chooser/champ_chooser.c
+++ b/src/server/protocol2/champ_chooser/champ_chooser.c
@@ -39,14 +39,13 @@ static int try_to_get_lock(struct lock *lock)
 				if(lock_tries>lock_tries_max)
 				{
 					try_lock_msg(lock_tries_max*sleeptime);
+					logp("Giving up.\n");
 					return -1;
 				}
 				// Log every 10 seconds.
 				if(lock_tries%(10/sleeptime))
 				{
-					try_lock_msg(lock_tries_max*sleeptime);
-					logp("Giving up.\n");
-					return -1;
+					try_lock_msg(lock_tries*sleeptime);
 				}
 				sleep(sleeptime);
 				continue;


### PR DESCRIPTION
I think this is a small typo, returning from an "in-progress" log defeats the purpose of having a max_tries variable :smile:

We are getting "Unable to get sparse lock for 3600 seconds." messages within 5 minutes after phase 3 end ; that was illogical so I investigated there.

By the way, I know that making conf variables for this takes more time but is a low sleep time (2 seconds) made on purpose ? I wonder whether long wait times are possible in production with many backups ; we would then try a disk operation (if I understand the lock code well) every 2 seconds and then log every 10 seconds, maybe a little bit overkill ?