### PR TITLE
scripts: remove hardcoded paths, generate them with Makefile instead.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /autoconf/test-driver
 /autom4te.cache
 /burp
+/burp_ca
 /burp.conf
 /burp-server.conf
 /burp-coverage/
@@ -32,6 +33,7 @@
 /runner.trs
 /src/server/protocol1/vss_strip
 /src/stamp-h1
+/summary_script
 /test-suite.log
 /utest_find/
 /utest_lockfile

--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,9 @@ EXTRA_DIST = \
 	android/README \
 	configs/client/burp.conf.in \
 	configs/server/burp.conf.in \
+	configs/server/summary_script.in \
 	configs/certs/CA/CA.cnf.in \
+	configs/certs/CA/burp_ca.in \
 	debian \
 	freebsd \
 	rhel \
@@ -85,13 +87,18 @@ bin_PROGRAMS = vss_strip
 
 sbin_PROGRAMS = burp
 
-dist_sbin_SCRIPTS = configs/certs/CA/burp_ca
+sbin_SCRIPTS = burp_ca
 
 dist_script_SCRIPTS = \
 	configs/server/timer_script \
 	configs/server/notify_script \
-	configs/server/ssl_extra_checks_script \
-	configs/server/summary_script
+	configs/server/ssl_extra_checks_script
+
+EXTRA_script_SCRIPTS = summary_script
+
+EXTRA_scriptdir = $(scriptdir)
+
+CLEANFILES+= $(sbin_SCRIPTS) $(EXTRA_script_SCRIPTS)
 
 vss_strip_SOURCES = src/server/protocol1/vss_strip.c
 
@@ -419,6 +426,14 @@ burp-server.conf: $(srcdir)/configs/server/burp.conf.in
 CA.cnf: $(srcdir)/configs/certs/CA/CA.cnf.in
 	$(AM_V_at)rm -f $@
 	$(AM_V_GEN)$(do_subst) <$(srcdir)/configs/certs/CA/CA.cnf.in >$@
+
+burp_ca: $(srcdir)/configs/certs/CA/burp_ca.in
+	$(AM_V_at)rm -f $@
+	$(AM_V_GEN)$(do_subst) <$(srcdir)/configs/certs/CA/burp_ca.in >$@
+
+summary_script: $(srcdir)/configs/server/summary_script.in
+	$(AM_V_at)rm -f $@
+	$(AM_V_GEN)$(do_subst) <$(srcdir)/configs/server/summary_script.in >$@
 
 do_subst = ( sed \
   -e 's,[@]localstatedir[@],$(localstatedir),g' \

--- a/configs/certs/CA/burp_ca.in
+++ b/configs/certs/CA/burp_ca.in
@@ -55,7 +55,7 @@ fi
 
 set -e
 
-etc=/etc/burp
+etc=@sysconfdir@
 dir=${etc}/CA
 conf=${etc}/CA.cnf
 ca_days=7300

--- a/configs/server/summary_script.in
+++ b/configs/server/summary_script.in
@@ -8,5 +8,5 @@ fi
 (echo "To: $2"
  echo "From: burp"
  echo "Subject: $3"
- /usr/sbin/burp -c "$1" -a S
+ @sbindir@/burp -c "$1" -a S
  echo) | /usr/sbin/sendmail -t


### PR DESCRIPTION
remove hardcoded paths in burp_ca and summary_script, compute them via Makefile instead.