### PR TITLE
add: disabled option

### DIFF
--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -460,6 +460,9 @@ Choose which style of backups and restores to use. 0 (the default) automatically
 \fBpassword=[password]\fR
 Defines the password to send to the server.
 .TP
+\fBdisabled=[0|1]\fR
+Set this to 1 if you want to disable a client. The default is 0. This option can also be set in the client configuration files in clientconfdir on the server.
+.TP
 \fBlockfile=[path]\fR
 Path to the lockfile that ensures that two client processes cannot run
 simultaneously (this currently doesn't work on Windows).

--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -460,8 +460,8 @@ Choose which style of backups and restores to use. 0 (the default) automatically
 \fBpassword=[password]\fR
 Defines the password to send to the server.
 .TP
-\fBdisabled=[0|1]\fR
-Set this to 1 if you want to disable a client. The default is 0. This option can also be set in the client configuration files in clientconfdir on the server.
+\fBenabled=[0|1]\fR
+Set this to 0 if you want to disable a client. The default is 1. This option can also be set in the client configuration files in clientconfdir on the server.
 .TP
 \fBlockfile=[path]\fR
 Path to the lockfile that ensures that two client processes cannot run

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -489,6 +489,12 @@ int client(struct conf **confs, enum action action, int vss_restore)
 {
 	enum cliret ret=CLIENT_OK;
 
+	if(get_int(confs[OPT_DISABLED]))
+	{
+		logp("Client disabled\n");
+		return ret;
+	}
+
 #ifdef HAVE_WIN32
 	// prevent sleep when idle
 	SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);

--- a/src/client/main.c
+++ b/src/client/main.c
@@ -489,9 +489,9 @@ int client(struct conf **confs, enum action action, int vss_restore)
 {
 	enum cliret ret=CLIENT_OK;
 
-	if(get_int(confs[OPT_DISABLED]))
+	if(!get_int(confs[OPT_ENABLED]))
 	{
-		logp("Client disabled\n");
+		logp("Client not enabled\n");
 		return ret;
 	}
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -490,8 +490,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "ca_csr_dir");
 	case OPT_RANDOMISE:
 	  return sc_int(c[o], 0, 0, "randomise");
-	case OPT_DISABLED:
-	  return sc_int(c[o], 0, 0, "disabled");
+	case OPT_ENABLED:
+	  return sc_int(c[o], 1, 0, "enabled");
 	case OPT_SERVER_CAN_OVERRIDE_INCLUDES:
 	  return sc_int(c[o], 1, 0, "server_can_override_includes");
 	case OPT_BACKUP:

--- a/src/conf.c
+++ b/src/conf.c
@@ -490,6 +490,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "ca_csr_dir");
 	case OPT_RANDOMISE:
 	  return sc_int(c[o], 0, 0, "randomise");
+	case OPT_DISABLED:
+	  return sc_int(c[o], 0, 0, "disabled");
 	case OPT_SERVER_CAN_OVERRIDE_INCLUDES:
 	  return sc_int(c[o], 1, 0, "server_can_override_includes");
 	case OPT_BACKUP:

--- a/src/conf.h
+++ b/src/conf.h
@@ -131,6 +131,7 @@ enum conf_opt
 	OPT_CNAME, // set on the server when client connects
 	OPT_PASSWORD, // also a clientconfdir option
 	OPT_PASSWD, // also a clientconfdir option
+	OPT_DISABLED, // also a clientconfdir option
 	OPT_SERVER,
 	OPT_ENCRYPTION_PASSWORD,
 	OPT_AUTOUPGRADE_OS,

--- a/src/conf.h
+++ b/src/conf.h
@@ -131,7 +131,7 @@ enum conf_opt
 	OPT_CNAME, // set on the server when client connects
 	OPT_PASSWORD, // also a clientconfdir option
 	OPT_PASSWD, // also a clientconfdir option
-	OPT_DISABLED, // also a clientconfdir option
+	OPT_ENABLED, // also a clientconfdir option
 	OPT_SERVER,
 	OPT_ENCRYPTION_PASSWORD,
 	OPT_AUTOUPGRADE_OS,

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -237,9 +237,9 @@ static int run_child(int *cfd, SSL_CTX *ctx, struct sockaddr_storage *addr,
 		goto end;
 	}
 
-	if(get_int(cconfs[OPT_DISABLED]))
+	if(!get_int(cconfs[OPT_ENABLED]))
 	{
-		log_and_send(as->asfd, "client disabled on server");
+		log_and_send(as->asfd, "client not enabled on server");
 		sleep(1);
 		goto end;
 	}

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -237,6 +237,13 @@ static int run_child(int *cfd, SSL_CTX *ctx, struct sockaddr_storage *addr,
 		goto end;
 	}
 
+	if(get_int(cconfs[OPT_DISABLED]))
+	{
+		log_and_send(as->asfd, "client disabled on server");
+		sleep(1);
+		goto end;
+	}
+
 	// Set up counters. Have to wait until here to get cname.
 	if(!(cntr=cntr_alloc())
 	  || cntr_init(cntr, cname))

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -78,6 +78,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 			break;
 		case OPT_CLIENT_IS_WINDOWS:
 		case OPT_RANDOMISE:
+		case OPT_DISABLED:
 		case OPT_B_SCRIPT_POST_RUN_ON_FAIL:
 		case OPT_R_SCRIPT_POST_RUN_ON_FAIL:
 		case OPT_SEND_CLIENT_CNTR:

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -78,7 +78,6 @@ static void check_default(struct conf **c, enum conf_opt o)
 			break;
 		case OPT_CLIENT_IS_WINDOWS:
 		case OPT_RANDOMISE:
-		case OPT_DISABLED:
 		case OPT_B_SCRIPT_POST_RUN_ON_FAIL:
 		case OPT_R_SCRIPT_POST_RUN_ON_FAIL:
 		case OPT_SEND_CLIENT_CNTR:
@@ -109,6 +108,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_DAEMON:
 		case OPT_STDOUT:
 		case OPT_FORK:
+		case OPT_ENABLED:
 		case OPT_DIRECTORY_TREE:
 		case OPT_PASSWORD_CHECK:
 		case OPT_LIBRSYNC:


### PR DESCRIPTION
Hello,

As discussed off-list, here is a patch that adds a new "disabled" option in order to disable a client.

You can either disable a client server-side or client-side.

If you add `disabled = 1` in your clientconfdir configuration file, the server will throw an error:

```
# burp -c /etc/burp/test.conf -a b
2016-04-26 16:50:14: burp[2705] auth ok
2016-04-26 16:50:14: burp[2705] Server version: 2.0.37
2016-04-26 16:50:14: burp[2705] main socket: expected 'c:nocsr ok', got 'e:client disabled on server'
2016-04-26 16:50:14: burp[2705] problem reading from server nocsr
2016-04-26 16:50:14: burp[2705] Error with cert signing request
```

I think we can improve this error though.

You can also disable a client client-side and here is the result:

```
# burp -c /etc/burp/test.conf -a b
2016-04-26 16:53:12: burp[2709] Client disabled
```