### PR TITLE
Fix status monitor summary (many lines for each client)

### DIFF
--- a/src/client/monitor/status_client_ncurses.c
+++ b/src/client/monitor/status_client_ncurses.c
@@ -52,20 +52,12 @@ static struct asfd *stdout_asfd=NULL;
 static void print_line_stdout(const char *string, int row, int col)
 {
 	int k=0;
-	const char *cp=NULL;
 	while(k<LEFT_SPACE)
 	{
 		stdout_asfd->write_str(stdout_asfd, CMD_GEN, " ");
 		k++;
 	}
-	for(cp=string; *cp; cp++)
-	{
-		stdout_asfd->write_str(stdout_asfd, CMD_GEN, string);
-		k+=strlen(string);
-#ifdef HAVE_NCURSES
-		if(actg==ACTION_STATUS && k<col) break;
-#endif
-	}
+	stdout_asfd->write_str(stdout_asfd, CMD_GEN, string);
 	stdout_asfd->write_str(stdout_asfd, CMD_GEN, "\n");
 }
 


### PR DESCRIPTION
This one is almost trivial but output broke our test scripts (seems to be related to recent asfd changes).
The status for each client was output many times (as many as the character count).

I removes the ACTION_STATUS test since the code seems to never reach `print_line_stdout` in this state (but rather `print_line_ncurses` instead)