### PR TITLE
add: option to force lowercase cname

### DIFF
--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -210,6 +210,9 @@ Defines the main TCP address that the server listens on for status requests. The
 \fBstatus_port=[port number]\fR
 Defines the TCP port that the server listens on for status requests. Comment this out to have no status server.
 .TP
+\fBforce_lowercase=[0|1]\fR
+Whether to force lowercase cname when looking-up in clientconfdir. The default is 0.
+.TP
 \fBdaemon=[0|1]\fR
 Whether to daemonise. The default is 1.
 .TP
@@ -689,6 +692,7 @@ The file needs to contain a line like \fBpassword=[password]\fR that matches the
 .TP
 Additionally, the following options can be overridden here for each client:
 \fBenabled\fR
+\fBforce_lowercase\fR
 \fBprotocol\fR
 \fBdirectory\fR
 \fBdirectory_tree\fR

--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -210,7 +210,7 @@ Defines the main TCP address that the server listens on for status requests. The
 \fBstatus_port=[port number]\fR
 Defines the TCP port that the server listens on for status requests. Comment this out to have no status server.
 .TP
-\fBforce_lowercase=[0|1]\fR
+\fBcname_lowercase=[0|1]\fR
 Whether to force lowercase cname when looking-up in clientconfdir. The default is 0.
 .TP
 \fBdaemon=[0|1]\fR
@@ -692,7 +692,6 @@ The file needs to contain a line like \fBpassword=[password]\fR that matches the
 .TP
 Additionally, the following options can be overridden here for each client:
 \fBenabled\fR
-\fBforce_lowercase\fR
 \fBprotocol\fR
 \fBdirectory\fR
 \fBdirectory_tree\fR

--- a/src/conf.c
+++ b/src/conf.c
@@ -476,8 +476,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "monitor_logfile");
 	case OPT_CNAME:
 	  return sc_str(c[o], 0, 0, "cname");
-	case OPT_FORCE_LOWERCASE:
-	  return sc_int(c[o], 0, CONF_FLAG_CC_OVERRIDE, "force_lowercase");
+	case OPT_CNAME_LOWERCASE:
+	  return sc_int(c[o], 0, 0, "cname_lowercase");
 	case OPT_PASSWORD:
 	  return sc_str(c[o], 0, 0, "password");
 	case OPT_PASSWD:

--- a/src/conf.c
+++ b/src/conf.c
@@ -476,6 +476,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "monitor_logfile");
 	case OPT_CNAME:
 	  return sc_str(c[o], 0, 0, "cname");
+	case OPT_FORCE_LOWERCASE:
+	  return sc_int(c[o], 0, CONF_FLAG_CC_OVERRIDE, "force_lowercase");
 	case OPT_PASSWORD:
 	  return sc_str(c[o], 0, 0, "password");
 	case OPT_PASSWD:
@@ -493,7 +495,7 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	case OPT_RANDOMISE:
 	  return sc_int(c[o], 0, 0, "randomise");
 	case OPT_ENABLED:
-	  return sc_int(c[o], 1, 0, "enabled");
+	  return sc_int(c[o], 1, CONF_FLAG_CC_OVERRIDE, "enabled");
 	case OPT_SERVER_CAN_OVERRIDE_INCLUDES:
 	  return sc_int(c[o], 1, 0, "server_can_override_includes");
 	case OPT_BACKUP:

--- a/src/conf.h
+++ b/src/conf.h
@@ -98,6 +98,7 @@ enum conf_opt
 	OPT_PROTOCOL,
 	OPT_RSHASH,
 	OPT_MESSAGE,
+	OPT_CNAME_LOWERCASE, // force lowercase cname, client or server option
 
 	// Server options.
 	OPT_ADDRESS,
@@ -127,7 +128,6 @@ enum conf_opt
 	OPT_MANUAL_DELETE,
 	OPT_MONITOR_LOGFILE, // An ncurses client option, from command line.
 	OPT_MONITOR_BROWSE_CACHE,
-	OPT_FORCE_LOWERCASE, // also a clientconfdir option, force lowercase cname
 
 	// Client options.
 	OPT_CNAME, // set on the server when client connects

--- a/src/conf.h
+++ b/src/conf.h
@@ -127,6 +127,7 @@ enum conf_opt
 	OPT_MANUAL_DELETE,
 	OPT_MONITOR_LOGFILE, // An ncurses client option, from command line.
 	OPT_MONITOR_BROWSE_CACHE,
+	OPT_FORCE_LOWERCASE, // also a clientconfdir option, force lowercase cname
 
 	// Client options.
 	OPT_CNAME, // set on the server when client connects

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -594,6 +594,7 @@ static int get_fqdn(struct conf **c)
 	struct addrinfo hints;
 	struct addrinfo *info=NULL;
 	char hostname[1024]="";
+	char *fqdn=NULL;
 	hostname[1023] = '\0';
 	if(gethostname(hostname, 1023))
 	{
@@ -621,13 +622,17 @@ static int get_fqdn(struct conf **c)
 		goto end;
 	}
 
-	if(set_string(c[OPT_CNAME], info->ai_canonname))
+	fqdn=strdup(info->ai_canonname);
+	if(get_int(c[OPT_CNAME_LOWERCASE])) strlwr(fqdn);
+
+	if(set_string(c[OPT_CNAME], fqdn))
 		goto end;
 	logp("cname from hostname: %s\n", get_string(c[OPT_CNAME]));
 
 	ret=0;
 end:
 	if(info) freeaddrinfo(info);
+	if(fqdn) free(fqdn);
 	return ret;
 }
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -622,8 +622,10 @@ static int get_fqdn(struct conf **c)
 		goto end;
 	}
 
-	fqdn=strdup(info->ai_canonname);
-	if(get_int(c[OPT_CNAME_LOWERCASE])) strlwr(fqdn);
+	if(!(fqdn=strdup_w(info->ai_canonname, __func__)))
+		goto end;
+	if(get_int(c[OPT_CNAME_LOWERCASE]))
+		strlwr(fqdn);
 
 	if(set_string(c[OPT_CNAME], fqdn))
 		goto end;
@@ -632,7 +634,7 @@ static int get_fqdn(struct conf **c)
 	ret=0;
 end:
 	if(info) freeaddrinfo(info);
-	if(fqdn) free(fqdn);
+	free_w(&fqdn);
 	return ret;
 }
 

--- a/src/handy.c
+++ b/src/handy.c
@@ -636,3 +636,10 @@ char *encode_time(time_t utime, char *buf)
 			tm->tm_hour, tm->tm_min, tm->tm_sec);
 	return buf+n;
 }
+
+char *strlwr(char *s)
+{
+	char *tmp=s;
+	for(;*tmp;++tmp) *tmp=tolower((unsigned char)*tmp);
+	return s;
+}

--- a/src/handy.h
+++ b/src/handy.h
@@ -57,6 +57,7 @@ extern void *malloc_w(size_t size, const char *func);
 extern void *calloc_w(size_t nmem, size_t size, const char *func);
 extern void free_v(void **ptr);
 extern void free_w(char **str);
+extern char *strlwr(char *s);
 
 extern int astrcat(char **buf, const char *append, const char *func);
 

--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -106,6 +106,7 @@ int authorise_server(struct asfd *asfd,
 	int ret=-1;
 	char *cp=NULL;
 	char *password=NULL;
+	char *cname=NULL;
 	char whoareyou[256]="";
 	struct iobuf *rbuf=asfd->rbuf;
 	const char *peer_version=NULL;
@@ -153,7 +154,12 @@ int authorise_server(struct asfd *asfd,
 		logp("unable to get client name\n");
 		goto end;
 	}
-	if(set_string(cconfs[OPT_CNAME], rbuf->buf))
+	cname=strdup(rbuf->buf);
+	if(get_int(cconfs[OPT_FORCE_LOWERCASE]))
+	{
+		strlwr(cname);
+	}
+	if(set_string(cconfs[OPT_CNAME], cname))
 		goto end;
 	iobuf_free_content(rbuf);
 
@@ -184,5 +190,6 @@ int authorise_server(struct asfd *asfd,
 end:
 	iobuf_free_content(rbuf);
 	free_w(&password);
+	if(cname) free(cname);
 	return ret;
 }

--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -154,11 +154,10 @@ int authorise_server(struct asfd *asfd,
 		logp("unable to get client name\n");
 		goto end;
 	}
+
 	cname=strdup(rbuf->buf);
-	if(get_int(cconfs[OPT_FORCE_LOWERCASE]))
-	{
-		strlwr(cname);
-	}
+	if(get_int(cconfs[OPT_CNAME_LOWERCASE])) strlwr(cname);
+
 	if(set_string(cconfs[OPT_CNAME], cname))
 		goto end;
 	iobuf_free_content(rbuf);

--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -156,7 +156,10 @@ int authorise_server(struct asfd *asfd,
 	}
 
 	cname=strdup(rbuf->buf);
-	if(get_int(cconfs[OPT_CNAME_LOWERCASE])) strlwr(cname);
+	if(!(cname=strdup_w(rbuf->buf, __func__)))
+		goto end;
+	if(get_int(cconfs[OPT_CNAME_LOWERCASE]))
+		strlwr(cname);
 
 	if(set_string(cconfs[OPT_CNAME], cname))
 		goto end;
@@ -189,6 +192,6 @@ int authorise_server(struct asfd *asfd,
 end:
 	iobuf_free_content(rbuf);
 	free_w(&password);
-	if(cname) free(cname);
+	free_w(&cname);
 	return ret;
 }

--- a/utest/server/test_auth.c
+++ b/utest/server/test_auth.c
@@ -11,7 +11,7 @@
 #define BASE		"utest_server_auth"
 #define CONFFILE	BASE "/burp.conf"
 
-int FORCE_LOWERCASE=0;
+int CNAME_LOWERCASE=0;
 
 static void clean(void)
 {
@@ -76,7 +76,7 @@ static void do_test(
 
 	fail_unless(!set_string(globalcs[OPT_CLIENTCONFDIR], CLIENTCONFDIR));
 
-	fail_unless(!set_int(cconfs[OPT_FORCE_LOWERCASE], FORCE_LOWERCASE));
+	fail_unless(!set_int(cconfs[OPT_CNAME_LOWERCASE], CNAME_LOWERCASE));
 
 	asfd=asfd_mock_setup(&reads, &writes);
 
@@ -264,7 +264,7 @@ START_TEST(test_authorise_server)
 	do_test(-1, setup_passwd_failed);
 	do_test(-1, setup_no_keep_configured);
 	do_test(-1, setup_lower_failed);
-	FORCE_LOWERCASE=1;
+	CNAME_LOWERCASE=1;
 	do_test(0, setup_lower_ok);
 }
 END_TEST

--- a/utest/server/test_auth.c
+++ b/utest/server/test_auth.c
@@ -263,7 +263,10 @@ START_TEST(test_authorise_server)
 	do_test(-1, setup_no_password_configured);
 	do_test(-1, setup_passwd_failed);
 	do_test(-1, setup_no_keep_configured);
+#ifndef HAVE_DARWIN_OS
+	// MacOSX has case insensitive fs so this test fails in such case
 	do_test(-1, setup_lower_failed);
+#endif
 	CNAME_LOWERCASE=1;
 	do_test(0, setup_lower_ok);
 }

--- a/utest/server/test_auth.c
+++ b/utest/server/test_auth.c
@@ -263,7 +263,7 @@ START_TEST(test_authorise_server)
 	do_test(-1, setup_no_password_configured);
 	do_test(-1, setup_passwd_failed);
 	do_test(-1, setup_no_keep_configured);
-	do_test(-1, setup_lower_failed);
+	//do_test(-1, setup_lower_failed);
 	CNAME_LOWERCASE=1;
 	do_test(0, setup_lower_ok);
 }

--- a/utest/server/test_auth.c
+++ b/utest/server/test_auth.c
@@ -263,7 +263,7 @@ START_TEST(test_authorise_server)
 	do_test(-1, setup_no_password_configured);
 	do_test(-1, setup_passwd_failed);
 	do_test(-1, setup_no_keep_configured);
-	//do_test(-1, setup_lower_failed);
+	do_test(-1, setup_lower_failed);
 	CNAME_LOWERCASE=1;
 	do_test(0, setup_lower_ok);
 }

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -18,7 +18,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_PORT:
 		case OPT_STATUS_ADDRESS:
 		case OPT_STATUS_PORT:
-        	case OPT_SSL_CERT_CA:
+		case OPT_SSL_CERT_CA:
 		case OPT_SSL_CERT:
 		case OPT_SSL_KEY:
 		case OPT_SSL_KEY_PASSWORD:
@@ -91,9 +91,8 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_S_SCRIPT_POST_NOTIFY:
 		case OPT_S_SCRIPT_NOTIFY:
 		case OPT_HARDLINKED_ARCHIVE:
-			// wrong indent?
-        	case OPT_N_SUCCESS_WARNINGS_ONLY:
-        	case OPT_N_SUCCESS_CHANGES_ONLY:
+		case OPT_N_SUCCESS_WARNINGS_ONLY:
+		case OPT_N_SUCCESS_CHANGES_ONLY:
 		case OPT_CROSS_ALL_FILESYSTEMS:
 		case OPT_READ_ALL_FIFOS:
 		case OPT_READ_ALL_BLOCKDEVS:
@@ -179,8 +178,8 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_EXCFS:
 		case OPT_EXCOM:
 		case OPT_INCGLOB:
-        	case OPT_FIFOS:
-        	case OPT_BLOCKDEVS:
+		case OPT_FIFOS:
+		case OPT_BLOCKDEVS:
 		case OPT_LABEL:
 			fail_unless(get_strlist(c[o])==NULL);
 			break;
@@ -193,17 +192,17 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_MAX_FILE_SIZE:
 			fail_unless(get_uint64_t(c[o])==0);
 			break;
-        	case OPT_WORKING_DIR_RECOVERY_METHOD:
+		case OPT_WORKING_DIR_RECOVERY_METHOD:
 			fail_unless(get_e_recovery_method(c[o])==
 				RECOVERY_METHOD_DELETE);
 			break;
-        	case OPT_RSHASH:
+		case OPT_RSHASH:
 			fail_unless(get_e_rshash(c[o])==RSHASH_UNSET);
 			break;
 		case OPT_CNTR:
 			fail_unless(get_cntr(c)==NULL);
 			break;
-        	case OPT_MAX:
+		case OPT_MAX:
 			break;
 		// No default, so we get compiler warnings if something was
 		// missed.

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -91,6 +91,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_S_SCRIPT_POST_NOTIFY:
 		case OPT_S_SCRIPT_NOTIFY:
 		case OPT_HARDLINKED_ARCHIVE:
+			// wrong indent?
         	case OPT_N_SUCCESS_WARNINGS_ONLY:
         	case OPT_N_SUCCESS_CHANGES_ONLY:
 		case OPT_CROSS_ALL_FILESYSTEMS:
@@ -101,6 +102,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_ATIME:
 		case OPT_SCAN_PROBLEM_RAISES_ERROR:
 		case OPT_OVERWRITE:
+		case OPT_FORCE_LOWERCASE:
 		case OPT_STRIP:
 		case OPT_MESSAGE:
 		case OPT_CA_CRL_CHECK:

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -102,7 +102,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_ATIME:
 		case OPT_SCAN_PROBLEM_RAISES_ERROR:
 		case OPT_OVERWRITE:
-		case OPT_FORCE_LOWERCASE:
+		case OPT_CNAME_LOWERCASE:
 		case OPT_STRIP:
 		case OPT_MESSAGE:
 		case OPT_CA_CRL_CHECK:


### PR DESCRIPTION
Hello,

As already discussed, when you are evolving in an heterogeneous environment (with MacOS, Windows and Linux clients), and you are using the default `cname` (returned by get_fqdn) you may end-up with mixed case `cname`s (Windows likes uppercase...).

This patch allows to force lowercase `cname` with the new option `cname_lowercase` which defaults to `0`.
The option can be set globally on the server or client-side.

