### PR TITLE
add: new cname_fqdn option to allow stripping FQDN

### DIFF
--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -211,7 +211,9 @@ Defines the main TCP address that the server listens on for status requests. The
 Defines the TCP port that the server listens on for status requests. Comment this out to have no status server.
 .TP
 \fBcname_lowercase=[0|1]\fR
-Whether to force lowercase cname when looking-up in clientconfdir. The default is 0.
+Whether to force lowercase cname when looking-up in clientconfdir. This also affects the fqdn lookup on the client. The default is 0.
+\fBcname_fqdn=[0|1]\fR
+Whether to keep fqdn cname (like 'testclient.example.com') when looking-up in clientconfdir. This also affects the fqdn lookup on the client. The default is 1.
 .TP
 \fBdaemon=[0|1]\fR
 Whether to daemonise. The default is 1.

--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -211,9 +211,9 @@ Defines the main TCP address that the server listens on for status requests. The
 Defines the TCP port that the server listens on for status requests. Comment this out to have no status server.
 .TP
 \fBcname_lowercase=[0|1]\fR
-Whether to force lowercase cname when looking-up in clientconfdir. This also affects the fqdn lookup on the client. The default is 0.
+Whether to force lowercase cname when looking-up in clientconfdir. This also affects the fqdn lookup on the client (see client configuration options for details). The default is 0. When set to 1 the name provided by the client while authenticating will be lowercased.
 \fBcname_fqdn=[0|1]\fR
-Whether to keep fqdn cname (like 'testclient.example.com') when looking-up in clientconfdir. This also affects the fqdn lookup on the client. The default is 1.
+Whether to keep fqdn cname (like 'testclient.example.com') when looking-up in clientconfdir. This also affects the fqdn lookup on the client (see client configuration options for details). The default is 1. When set to 0, the fqdn provided by the client while authenticating will be stripped ('testclient.example.com' becomes 'testclient').
 .TP
 \fBdaemon=[0|1]\fR
 Whether to daemonise. The default is 1.
@@ -468,6 +468,10 @@ Defines the TCP port that the server is listening on.
 .TP
 \fBcname=[password]\fR
 Defines the client name to identify as to the server.
+\fBcname_lowercase=[0|1]\fR
+Whether to force lowercase cname when detecting cname automatically (ie. no cname provided above). The default is 0. When set to 1 the name returned by the get_fqdn function will be lowercased.
+\fBcname_fqdn=[0|1]\fR
+Whether to keep fqdn cname (like 'testclient.example.com') when detecting cname automatically (ie. no cname provided above). The default is 1. When set to 0, the fqdn returned by the get_fqdn function will be stripped ('testclient.example.com' becomes 'testclient').
 .TP
 \fBprotocol=[0|1|2]\fR
 Choose which style of backups and restores to use. 0 (the default) automatically decides based on the server version and which protocol is set on the server side. 1 forces protocol1 style (file level granularity with a pseudo mirrored storage on the server and optional rsync). 2 forces protocol2 style (inline deduplication with variable length blocks). If you choose a forced setting, it will be an error if the server also chooses a forced setting.

--- a/src/conf.c
+++ b/src/conf.c
@@ -478,6 +478,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "cname");
 	case OPT_CNAME_LOWERCASE:
 	  return sc_int(c[o], 0, 0, "cname_lowercase");
+	case OPT_CNAME_FQDN:
+	  return sc_int(c[o], 1, 0, "cname_fqdn");
 	case OPT_PASSWORD:
 	  return sc_str(c[o], 0, 0, "password");
 	case OPT_PASSWD:

--- a/src/conf.h
+++ b/src/conf.h
@@ -99,6 +99,7 @@ enum conf_opt
 	OPT_RSHASH,
 	OPT_MESSAGE,
 	OPT_CNAME_LOWERCASE, // force lowercase cname, client or server option
+	OPT_CNAME_FQDN, // use fqdn cname, client or server option
 
 	// Server options.
 	OPT_ADDRESS,

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -624,6 +624,8 @@ static int get_fqdn(struct conf **c)
 
 	if(!(fqdn=strdup_w(info->ai_canonname, __func__)))
 		goto end;
+	if(!get_int(c[OPT_CNAME_FQDN]))
+		strip_fqdn(&fqdn);
 	if(get_int(c[OPT_CNAME_LOWERCASE]))
 		strlwr(fqdn);
 

--- a/src/handy.c
+++ b/src/handy.c
@@ -644,30 +644,13 @@ char *strlwr(char *s)
 	return s;
 }
 
-char *strip_fqdn(char **fqdn_p)
+void strip_fqdn(char **fqdn)
 {
-	char *fqdn=*fqdn_p;
-	char *non_fqdn=NULL;
-	char *tmp=NULL;
-	tmp=strchr(fqdn,'.');
-	if(tmp)
-	{
-		size_t s = strlen(fqdn)-strlen(tmp)+1;
-		int r;
-		non_fqdn=(char *)malloc_w(s*sizeof(char), __func__);
-		if(!non_fqdn)
-			return fqdn;
-		r = snprintf(non_fqdn, s, fqdn);
-		if(r<0)
-		{
-			free_w(&non_fqdn);
-			logp("Failed to strip FQDN (%s)\n", fqdn);
-			return fqdn;
-		}
-		free_w(fqdn_p);
-		*fqdn_p=non_fqdn;
-		return non_fqdn;
-	}
-	return fqdn;
+	char *tmp;
+	if(!fqdn || !*fqdn)
+		return;
+	tmp=strchr(*fqdn,'.');
+	if((tmp=strchr(*fqdn, '.')))
+		*tmp='\0';
 }
 

--- a/src/handy.c
+++ b/src/handy.c
@@ -649,7 +649,6 @@ void strip_fqdn(char **fqdn)
 	char *tmp;
 	if(!fqdn || !*fqdn)
 		return;
-	tmp=strchr(*fqdn,'.');
 	if((tmp=strchr(*fqdn, '.')))
 		*tmp='\0';
 }

--- a/src/handy.c
+++ b/src/handy.c
@@ -643,3 +643,31 @@ char *strlwr(char *s)
 	for(;*tmp;++tmp) *tmp=tolower((unsigned char)*tmp);
 	return s;
 }
+
+char *strip_fqdn(char **fqdn_p)
+{
+	char *fqdn=*fqdn_p;
+	char *non_fqdn=NULL;
+	char *tmp=NULL;
+	tmp=strchr(fqdn,'.');
+	if(tmp)
+	{
+		size_t s = strlen(fqdn)-strlen(tmp)+1;
+		int r;
+		non_fqdn=(char *)malloc_w(s*sizeof(char), __func__);
+		if(!non_fqdn)
+			return fqdn;
+		r = snprintf(non_fqdn, s, fqdn);
+		if(r<0)
+		{
+			free_w(&non_fqdn);
+			logp("Failed to strip FQDN (%s)\n", fqdn);
+			return fqdn;
+		}
+		free_w(fqdn_p);
+		*fqdn_p=non_fqdn;
+		return non_fqdn;
+	}
+	return fqdn;
+}
+

--- a/src/handy.h
+++ b/src/handy.h
@@ -58,7 +58,7 @@ extern void *calloc_w(size_t nmem, size_t size, const char *func);
 extern void free_v(void **ptr);
 extern void free_w(char **str);
 extern char *strlwr(char *s);
-extern char *strip_fqdn(char **fqdn_p);
+extern void strip_fqdn(char **fqdn);
 
 extern int astrcat(char **buf, const char *append, const char *func);
 

--- a/src/handy.h
+++ b/src/handy.h
@@ -58,6 +58,7 @@ extern void *calloc_w(size_t nmem, size_t size, const char *func);
 extern void free_v(void **ptr);
 extern void free_w(char **str);
 extern char *strlwr(char *s);
+extern char *strip_fqdn(char **fqdn_p);
 
 extern int astrcat(char **buf, const char *append, const char *func);
 

--- a/src/server/auth.c
+++ b/src/server/auth.c
@@ -155,9 +155,10 @@ int authorise_server(struct asfd *asfd,
 		goto end;
 	}
 
-	cname=strdup(rbuf->buf);
 	if(!(cname=strdup_w(rbuf->buf, __func__)))
 		goto end;
+	if(!get_int(cconfs[OPT_CNAME_FQDN]))
+		strip_fqdn(&cname);
 	if(get_int(cconfs[OPT_CNAME_LOWERCASE]))
 		strlwr(cname);
 

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -115,6 +115,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_LIBRSYNC:
 		case OPT_VERSION_WARN:
 		case OPT_PATH_LENGTH_WARN:
+		case OPT_CNAME_FQDN:
 		case OPT_CLIENT_CAN_DELETE:
 		case OPT_CLIENT_CAN_DIFF:
 		case OPT_CLIENT_CAN_FORCE_BACKUP:


### PR DESCRIPTION
Hello,

As discussed in #446, on a heterogeneous environment, it's hard to rely on the default *get_fqdn* function.
I have some examples where MacOS returns `hostname.local`, Windows returns `HOSTNAME` and Linux returns `hostname.f.q.d.n`.

The new `cname_fqdn` option allows to strip the fqdn either client-side (in the *get_fqdn* function), or server-side while authenticating the client.

The option defaults to `1` so it does not change the current behavior.