### PR TITLE
status_client_ncurses.c: fix two compiler warnings

### DIFF
--- a/src/client/monitor/status_client_ncurses.c
+++ b/src/client/monitor/status_client_ncurses.c
@@ -1198,9 +1198,7 @@ static void page_down_backup(struct sel *sel, int row)
 
 static void page_up(struct sel *sel)
 {
-	int row=0;
-	int col=0;
-	getmaxyx(stdscr, row, col);
+	int row=getmaxy(stdscr);
 	switch(sel->page)
 	{
 		case PAGE_CLIENT_LIST:
@@ -1218,9 +1216,7 @@ static void page_up(struct sel *sel)
 
 static void page_down(struct sel *sel)
 {
-	int row=0;
-	int col=0;
-	getmaxyx(stdscr, row, col);
+	int row=getmaxy(stdscr);
 	switch(sel->page)
 	{
 		case PAGE_CLIENT_LIST:


### PR DESCRIPTION
src/client/monitor/status_client_ncurses.c: In function ‘page_up’:
src/client/monitor/status_client_ncurses.c:1202:6: warning: variable ‘col’ set but not used [-Wunused-but-set-variable]
  int col=0;
      ^~~
src/client/monitor/status_client_ncurses.c: In function ‘page_down’:
src/client/monitor/status_client_ncurses.c:1222:6: warning: variable ‘col’ set but not used [-Wunused-but-set-variable]
  int col=0;
      ^~~