### PR TITLE
Fix debug build without optimization

### DIFF
--- a/src/burpconfig.h
+++ b/src/burpconfig.h
@@ -32,7 +32,7 @@
 	#define O_BINARY 0
 #endif
 
-inline uint8_t IsPathSeparator(int ch)
+static inline uint8_t IsPathSeparator(int ch)
 {
 	return
 #ifdef HAVE_WIN32


### PR DESCRIPTION
src/client/burp-find.o: In function `found_directory':
find.c:(.text+0xf33): undefined reference to `IsPathSeparator'
collect2: error: ld returned 1 exit status
Makefile:1767: recipe for target 'burp' failed
make: *** [burp] Error 1