### PR TITLE
BurpFS support

### DIFF
--- a/src/server/monitor/browse.c
+++ b/src/server/monitor/browse.c
@@ -14,7 +14,7 @@
 static int do_browse_manifest(
 	struct manio *manio, struct sbuf *sb, const char *browse)
 {
-	int browse_all = !strncmp(browse, "*", 1)? 1:0;
+	int browse_all = (browse && !strncmp(browse, "*", 1))? 1:0;
 	int ret=-1;
 	int ars=0;
 	//char ls[1024]="";
@@ -88,7 +88,7 @@ int browse_manifest(struct cstat *cstat,
 {
 	/* if browse directory is *, we dump all file entries, with full path
            we also avoid caching the whole list */
-	if (!strncmp(browse, "*", 1))
+	if (browse && !strncmp(browse, "*", 1))
 	{
         	use_cache = 0;
 	}

--- a/src/server/monitor/browse.c
+++ b/src/server/monitor/browse.c
@@ -14,6 +14,7 @@
 static int do_browse_manifest(
 	struct manio *manio, struct sbuf *sb, const char *browse)
 {
+	int browse_all = !strncmp(browse, "*", 1)? 1:0;
 	int ret=-1;
 	int ars=0;
 	//char ls[1024]="";
@@ -43,9 +44,11 @@ static int do_browse_manifest(
 		  && !cmd_is_link(sb->path.cmd))
 			continue;
 
-		if((r=check_browsedir(browse, sb, blen, &last_bd_match))<0)
-			goto end;
-		if(!r) continue;
+		if(!browse_all) {
+			if((r=check_browsedir(browse, sb, blen, &last_bd_match))<0)
+				goto end;
+			if(!r) continue;
+		}
 
 		if(json_from_entry(sb->path.buf, sb->link.buf, &sb->statp)) goto end;
 	}
@@ -83,6 +86,12 @@ end:
 int browse_manifest(struct cstat *cstat,
 	struct bu *bu, const char *browse, int use_cache)
 {
+	/* if browse directory is *, we dump all file entries, with full path
+           we also avoid caching the whole list */
+	if (!strncmp(browse, "*", 1))
+	{
+        	use_cache = 0;
+	}
 	if(use_cache)
 	{
 		if(!cache_loaded(cstat->name, bu->bno)

--- a/src/server/monitor/browse.c
+++ b/src/server/monitor/browse.c
@@ -47,7 +47,7 @@ static int do_browse_manifest(
 			goto end;
 		if(!r) continue;
 
-		if(json_from_statp(sb->path.buf, &sb->statp)) goto end;
+		if(json_from_entry(sb->path.buf, sb->link.buf, &sb->statp)) goto end;
 	}
 
 	ret=0;

--- a/src/server/monitor/json_output.c
+++ b/src/server/monitor/json_output.c
@@ -456,10 +456,11 @@ end:
 	return ret;
 }
 
-int json_from_statp(const char *path, struct stat *statp)
+int json_from_entry(const char *path, const char *link, struct stat *statp)
 {
 	return yajl_map_open_w()
 	  || yajl_gen_str_pair_w("name", path)
+	  || yajl_gen_str_pair_w("link", link? link:"")
 	  || yajl_gen_int_pair_w("dev", statp->st_dev)
 	  || yajl_gen_int_pair_w("ino", statp->st_ino)
 	  || yajl_gen_int_pair_w("mode", statp->st_mode)

--- a/src/server/monitor/json_output.h
+++ b/src/server/monitor/json_output.h
@@ -8,7 +8,7 @@ extern int json_send(struct asfd *asfd,
 	struct cstat *clist, struct cstat *cstat,
         struct bu *bu, const char *logfile, const char *browse,
 	int use_cache);
-extern int json_from_statp(const char *path, struct stat *statp);
+extern int json_from_entry(const char *path, const char *link, struct stat *statp);
 extern int json_cntr(struct asfd *asfd, struct cntr *cntr);
 
 extern int json_send_warn(struct asfd *asfd, const char *msg);


### PR DESCRIPTION
Hi,

I've modified the monitor directory browse functionality to allow BurpFS to run with burp 2.x 

1. A new `link` field was added to the json file entries. This field contains the target path of links. This seems like a sensible fix in general, aside for supporting burpfs, so it's packaged in its own commit.
2. The directory browse command will treat the path `*` in a special way -  the browser will dump all file entries, **without searching** for a specific directory prefix (the `name` field of each entry is thus unmodified and contains the **full path**), and **without caching**. This allows burpfs to avoid the potentially very slow process of querying the monitor for each sub-directory in the manifest.

Please review and pull.
Thanks,
Avi