### PR TITLE
bugfix: restored hardlink path was truncated if longer than target path

### DIFF
--- a/src/server/restore.c
+++ b/src/server/restore.c
@@ -196,6 +196,7 @@ static int hard_link_substitution(struct asfd *asfd,
 			free_w(&hb->path.buf);
 			if(!(hb->path.buf=strdup_w(sb->path.buf, __func__)))
 				goto end;
+			hb->path.len = sb->path.len;
 			// Should now be able to restore the original data
 			// to the new location.
 			ret=restore_sbuf(asfd, hb, bu, act, sdirs,


### PR DESCRIPTION
Hi,

If a hardlink path is longer than its target (e.g. `/root/test2.txt` points to `/root/test.txt`) then it is restored with a truncated filename (`test2.tx` in our example).

Please review and pull.
Thanks,
Avi 