### PR TITLE
Fix build failure on 32-bit architectures with modern gcc.

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -538,7 +538,7 @@ static void do_build_regex(struct strlist **list, int count, struct strlist ***d
 struct fstype
 {
 	const char *str;
-	long flag;
+	unsigned int flag;
 };
 
 static struct fstype fstypes[]={
@@ -590,7 +590,7 @@ int main(int argc, char *argv[])
 
 #endif
 
-static int fstype_to_flag(const char *fstype, long *flag)
+static int fstype_to_flag(const char *fstype, unsigned int *flag)
 {
 #ifdef HAVE_LINUX_OS
 	int i=0;

--- a/src/strlist.c
+++ b/src/strlist.c
@@ -21,7 +21,7 @@ void strlists_free(struct strlist **bd, int count)
 	}
 }
 
-int strlist_add(struct strlist ***bdlist, int *count, char *path, long flag)
+int strlist_add(struct strlist ***bdlist, int *count, char *path, unsigned int flag)
 {
 	//int b=0;
 	struct strlist *bdnew=NULL;

--- a/src/strlist.h
+++ b/src/strlist.h
@@ -11,13 +11,13 @@ typedef struct strlist strlist_t;
 
 struct strlist
 {
-	long flag;
+	unsigned int flag;
 	char *path;
 	regex_t *re;
 };
 
 extern void strlists_free(struct strlist **bd, int count);
-extern int strlist_add(struct strlist ***bdlist, int *count, char *path, long flag);
+extern int strlist_add(struct strlist ***bdlist, int *count, char *path, unsigned int flag);
 extern int strlist_sort(struct strlist **a, struct strlist **b);
 
 #endif


### PR DESCRIPTION
```
conf.c:567:1: error: narrowing conversion of '2240043254u' from
'unsigned int' to 'long int' inside { } [-Wnarrowing]
```
Using a "long" to store unsigned 32-bit values is wrong everywhere: on 32-bit archs new gcc (rightfully) complains about overflow, on 64-bit archs that's merely some waste.