### PR TITLE
Allow removing of arbitrary strings from res. path

### DIFF
--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -787,6 +787,9 @@ Number of leading path components to strip. Equivalent to '\-s' when initiating 
 \fBrestoreprefix=[path]\fR
 Prefix to the restore path. Equivalent to '\-d' when initiating a restore from the client.
 .TP
+\fBstripfrompath=[string]\fR
+Strip matching string from restore paths (before prefix is prepended).
+.TP
 \fBregex=[regular expression]\fR
 Only restore files matching the regular expression. Equivalent to '\-r' when initiating a restore from the client.
 .TP

--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -388,7 +388,7 @@ static const char *act_str(enum action act)
 
 void strip_from_path(char *path, const char *strip)
 {
-	if (strlen(path) > strlen(strip))
+	if (path && strip && strlen(path) > strlen(strip))
 	{
 		char *p = strstr(path, strip);
 		if(p != NULL)

--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -386,6 +386,21 @@ static const char *act_str(enum action act)
 	return ret;
 }
 
+void strip_from_path(char *path, const char *strip)
+{
+	if (strlen(path) > strlen(strip))
+	{
+		char *p = strstr(path, strip);
+		if(p != NULL)
+		{
+			size_t len = strlen(p) - strlen(strip) + 1;
+			char *src = p + strlen(strip);
+			memmove(p, src, len);
+		}
+	}
+}
+
+
 // Return 1 for ok, -1 for error, 0 for too many components stripped.
 static int strip_path_components(struct asfd *asfd,
 	struct sbuf *sb, int strip, struct cntr *cntr, enum protocol protocol)
@@ -537,6 +552,7 @@ int do_restore_client(struct asfd *asfd,
 	enum protocol protocol=get_protocol(confs);
 	int strip=get_int(confs[OPT_STRIP]);
 	int overwrite=get_int(confs[OPT_OVERWRITE]);
+	const char *strip_path=get_string(confs[OPT_STRIP_FROM_PATH]);
 	const char *backup=get_string(confs[OPT_BACKUP]);
 	const char *regex=get_string(confs[OPT_REGEX]);
 	const char *restore_prefix=get_string(confs[OPT_RESTOREPREFIX]);
@@ -637,6 +653,10 @@ int do_restore_client(struct asfd *asfd,
 						continue;
 					}
 					// It is OK, sb.path is now stripped.
+				}
+				if(strip_path && strlen(strip_path)) {
+					strip_from_path(sb->path.buf,
+						strip_path);
 				}
 				free_w(&fullpath);
 				if(!(fullpath=prepend_s(restore_prefix,

--- a/src/conf.c
+++ b/src/conf.c
@@ -496,6 +496,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "backup2");
 	case OPT_RESTOREPREFIX:
 	  return sc_str(c[o], 0, CONF_FLAG_INCEXC_RESTORE, "restoreprefix");
+	case OPT_STRIP_FROM_PATH:
+	  return sc_str(c[o], 0, CONF_FLAG_INCEXC_RESTORE, "stripfrompath");
 	case OPT_BROWSEFILE:
 	  return sc_str(c[o], 0, 0, "browsefile");
 	case OPT_BROWSEDIR:

--- a/src/conf.h
+++ b/src/conf.h
@@ -174,6 +174,7 @@ enum conf_opt
 	// These are to do with restore.
 	OPT_OVERWRITE,
 	OPT_STRIP,
+	OPT_STRIP_FROM_PATH,
 	OPT_BACKUP,
 	OPT_BACKUP2, // For diffs.
 	OPT_RESTOREPREFIX,

--- a/src/log.c
+++ b/src/log.c
@@ -199,6 +199,9 @@ void log_restore_settings(struct conf **cconfs, int srestore)
 	if(get_string(cconfs[OPT_RESTOREPREFIX]))
 		logp("restoreprefix = '%s'\n",
 			get_string(cconfs[OPT_RESTOREPREFIX]));
+	if(get_string(cconfs[OPT_STRIP_FROM_PATH]))
+		logp("stripfrompath = '%s'\n",
+			get_string(cconfs[OPT_STRIP_FROM_PATH]));
 	if(get_string(cconfs[OPT_REGEX]))
 		logp("regex = '%s'\n", get_string(cconfs[OPT_REGEX]));
 	for(l=get_strlist(cconfs[OPT_INCLUDE]); l; l=l->next)

--- a/src/prog.c
+++ b/src/prog.c
@@ -275,6 +275,7 @@ int real_main(int argc, char *argv[])
 	const char *backup=NULL;
 	const char *backup2=NULL;
 	char *restoreprefix=NULL;
+	char *stripfrompath=NULL;
 	const char *regex=NULL;
 	const char *browsefile=NULL;
 	char *browsedir=NULL;
@@ -491,6 +492,7 @@ int real_main(int argc, char *argv[])
 	if(replace_conf_str(confs[OPT_BACKUP], backup)
 	  || replace_conf_str(confs[OPT_BACKUP2], backup2)
 	  || replace_conf_str(confs[OPT_RESTOREPREFIX], restoreprefix)
+	  || replace_conf_str(confs[OPT_STRIP_FROM_PATH], stripfrompath)
 	  || replace_conf_str(confs[OPT_REGEX], regex)
 	  || replace_conf_str(confs[OPT_BROWSEFILE], browsefile)
 	  || replace_conf_str(confs[OPT_BROWSEDIR], browsedir)

--- a/utest/client/test_restore.c
+++ b/utest/client/test_restore.c
@@ -18,6 +18,8 @@
 
 #define BASE	"utest_restore"
 
+extern void strip_from_path(char *path, const char *strip);
+
 static struct ioevent_list reads;
 static struct ioevent_list writes;
 
@@ -360,6 +362,48 @@ START_TEST(test_restore_proto2_interrupt)
 }
 END_TEST
 
+START_TEST(test_strip_from_path)
+{
+	char test[256];
+	char expected[256];
+
+	snprintf(test, sizeof(test), "/path/to/a/file");
+	snprintf(expected, sizeof(expected), "/path/file");
+	strip_from_path(test, "/to/a");
+	fail_unless(strcmp(test,expected)==0);
+
+	snprintf(test, sizeof(test), "/path/to/a/file/to/a/foo");
+	snprintf(expected, sizeof(expected), "/path/file/to/a/foo");
+	strip_from_path(test, "/to/a");
+	fail_unless(strcmp(test,expected)==0);
+
+	snprintf(test, sizeof(test), "/path/to/a/file");
+	snprintf(expected, sizeof(expected), "/path/to/a/file");
+	strip_from_path(test, "/path/to/a/file");
+	fail_unless(strcmp(test,expected)==0);
+
+	snprintf(test, sizeof(test), "/path/to/a/file");
+	snprintf(expected, sizeof(expected), "path/to/a/file");
+	strip_from_path(test, "/");
+	fail_unless(strcmp(test,expected)==0);
+
+	snprintf(test, sizeof(test), "/path/to/a/file/");
+	snprintf(expected, sizeof(expected), "/");
+	strip_from_path(test, "/path/to/a/file");
+	fail_unless(strcmp(test,expected)==0);
+
+	snprintf(test, sizeof(test), "/path/to/a/file");
+	snprintf(expected, sizeof(expected), "/path/to/a/file");
+	strip_from_path(test, "");
+	fail_unless(strcmp(test,expected)==0);
+
+	snprintf(test, sizeof(test), "/path/to/a/file");
+	snprintf(expected, sizeof(expected), "/path/to/a/file");
+	strip_from_path(test, NULL);
+	fail_unless(strcmp(test,expected)==0);
+}
+END_TEST
+
 Suite *suite_client_restore(void)
 {
 	Suite *s;
@@ -378,6 +422,8 @@ Suite *suite_client_restore(void)
 
 	tcase_add_test(tc_core, test_restore_proto2_bad_read);
 	tcase_add_test(tc_core, test_restore_proto2_some_things);
+	tcase_add_test(tc_core, test_strip_from_path);
+
 	tcase_add_test(tc_core, test_restore_proto2_interrupt);
 
 	suite_add_tcase(s, tc_core);

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -44,6 +44,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_BACKUP:
 		case OPT_BACKUP2:
 		case OPT_RESTOREPREFIX:
+		case OPT_STRIP_FROM_PATH:
 		case OPT_BROWSEFILE:
 		case OPT_BROWSEDIR:
 		case OPT_B_SCRIPT_PRE:


### PR DESCRIPTION
Hello,

I'm planning/evaluation to use Burp to backup, among other things, ZFS filesystems. Sometimes you want to backup from a snapshot, which means there is a `/.zfs/snapshots/[^/]+` comoponent in all paths. Files can't be restored in place like this, since ZFS snapshots are always read-only. So I implemented a way to cut out arbitrary strings from restore paths to be able to get rid of those on restore.

Preliminary manual tests on Debian Jessie, FreeBSD 10.3 and Solaris 10 are looking good to me.