### PR TITLE
fix config check logic for ca_burp_ca

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -715,7 +715,7 @@ static int client_conf_checks(struct conf **c, const char *path, int *r)
 	  && strstr(autoupgrade_os, ".."))
 		conf_problem(path,
 			"autoupgrade_os must not contain a '..' component", r);
-	if(!get_string(c[OPT_CA_BURP_CA]))
+	if(get_string(c[OPT_CA_BURP_CA]))
 	{
 		if(!get_string(c[OPT_CA_CSR_DIR]))
 			conf_problem(path,


### PR DESCRIPTION
Error messages for subsequent checks indicate that ca_burp_ca should be set
but the preceding check for ca_burp_ca tests for _not_ being set.