### PR TITLE
Make struct dirent UTF-8-alike

### DIFF
--- a/src/win32/compat/compat.h
+++ b/src/win32/compat/compat.h
@@ -137,7 +137,7 @@ struct dirent
 	uint64_t d_ino;
 	uint32_t d_off;
 	uint16_t d_reclen;
-	char d_name[256];
+	char d_name[MAX_PATH_UTF8]; // Scince we use UTF-8, it must be so large
 };
 typedef void DIR;
 


### PR DESCRIPTION
I've received strange clients' failures on directories with long non-english names.
This point seems to be root of trouble.