### PR TITLE
Set windows d_name buffer to MAX_PATH_UTF8

### DIFF
--- a/src/burp.h
+++ b/src/burp.h
@@ -77,13 +77,13 @@
 // Local Burp includes. Be sure to put all the system includes before these.
 #ifdef HAVE_WIN32
 	#include <windows.h>
+	#include "win32/winapi.h"
 	#include "win32/compat/compat.h"
 #endif
 
 #include "burpconfig.h"
 
 #ifdef HAVE_WIN32
-	#include "win32/winapi.h"
 	#include "winhost.h"
 #endif
 

--- a/src/win32/compat/compat.h
+++ b/src/win32/compat/compat.h
@@ -137,7 +137,7 @@ struct dirent
 	uint64_t d_ino;
 	uint32_t d_off;
 	uint16_t d_reclen;
-	char d_name[MAX_PATH];
+	char d_name[MAX_PATH_UTF8];
 };
 typedef void DIR;
 


### PR DESCRIPTION
Once again.

Windows says MAX_PATH is about 260 UCS-2 symbols.
Non-english symbols uses at least 2 bytes in UTF-8, so max 127 such symbols are fit in MAX_PATH. 
