### PR TITLE
Add ZFS to fstypes

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -200,6 +200,7 @@ static struct fstype fstypes[]={
 	{ "ramfs",		0x858458f6 },
 	{ "romfs",		0x00007275 },
 	{ "tmpfs",		0x01021994 },
+	{ "zfs",		0x2fc12fc1 },
 	{ NULL,			0 },
 };
 /* Use this C code to figure out what f_type gets set to.


### PR DESCRIPTION
Hi, this adds ZFS to the fstypes list, so that it can be excluded using exclude_fs.