### PR TITLE
Partial fix for #516

### DIFF
--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -666,7 +666,7 @@ int do_restore_client(struct asfd *asfd,
 					strip_from_path(sb->path.buf,
 						strip_path);
 					// Strip links if their path is absolute
-					if (sb->link.buf && strchr(sb->link.buf, '/') == sb->link.buf)
+					if(is_not_absolute(sb->link.buf, NULL))
 						strip_from_path(sb->link.buf,
 							strip_path);
 				}

--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -8,6 +8,7 @@
 #include "../cntr.h"
 #include "../fsops.h"
 #include "../handy.h"
+#include "../pathcmp.h"
 #include "../log.h"
 #include "../prepend.h"
 #include "../protocol2/blk.h"

--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -662,8 +662,14 @@ int do_restore_client(struct asfd *asfd,
 					// It is OK, sb.path is now stripped.
 				}
 				if(strip_path)
+				{
 					strip_from_path(sb->path.buf,
 						strip_path);
+					// Strip links if their path is absolute
+					if (sb->link.buf && strchr(sb->link.buf, '/') == sb->link.buf)
+						strip_from_path(sb->link.buf,
+							strip_path);
+				}
 				free_w(&fullpath);
 				if(!(fullpath=prepend_s(restore_prefix,
 					sb->path.buf)))

--- a/src/pathcmp.c
+++ b/src/pathcmp.c
@@ -27,6 +27,35 @@ int is_subdir(const char *dir, const char *sub)
 	return 0;
 }
 
+int is_not_absolute(const char *path, const char *err_msg)
+{
+        const char *p=NULL;
+        for(p=path; *p; p++)
+        {
+                if(*p!='.' || *(p+1)!='.') continue;
+                if((p==path || *(p-1)=='/') && (*(p+2)=='/' || !*(p+2)))
+                {
+                        if (err_msg)
+                                logp("%s", err_msg);
+                        return -1;
+                }
+        }
+// This is being run on the server too, where you can enter paths for the
+// clients, so need to allow windows style paths for windows and unix.
+        if((!isalpha(*path) || *(path+1)!=':')
+#ifndef HAVE_WIN32
+        // Windows does not need to check for unix style paths.
+          && *path!='/'
+#endif
+        )
+        {
+                if(err_msg)
+                        logp("%s", err_msg);
+                return -1;
+        }
+        return 0;
+}
+
 int pathcmp(const char *a, const char *b)
 {
 	// This should have used 'unsigned chars', but now its too late and

--- a/src/pathcmp.h
+++ b/src/pathcmp.h
@@ -2,6 +2,8 @@
 #define _PATHCMP_H
 
 extern int is_subdir(const char *dir, const char *sub);
+extern int is_not_absolute(const char *path, const char *err_msg);
 extern int pathcmp(const char *a, const char *b);
+
 
 #endif


### PR DESCRIPTION
Calls `src/client/restore.c:strip_from_path()` on absolute link paths.

Does not fix `src/client/restore.c:strip_from_path()` or `src/server/restore.c:hard_link_substitution()`.