### PR TITLE
Fix burp_ca for SunOS

### DIFF
--- a/configs/certs/CA/burp_ca.in
+++ b/configs/certs/CA/burp_ca.in
@@ -45,15 +45,11 @@ while ! lock; do
 	fi
 done
 
-case "$(uname -s)" init
-	# Solaris derivates don't support 'hostname -f' and, in fact,
-	# set the hostname to '-f' with that call.
-	SunOS)
-		name=$( (check-hostname | cut -d' ' -f7) 2>/dev/null )
-	;;
-	*)
-		name=$(hostname -f 2>/dev/null)
-	;;
+# Solaris derivates don't support 'hostname -f' and, in fact,
+# set the hostname to '-f' with that call.
+case "$(uname -s)" in
+	SunOS) name=$( (check-hostname | cut -d' ' -f7) 2>/dev/null ) ;;
+	*) name=$(hostname -f 2>/dev/null) ;;
 esac
 # Try NetBSD style.
 [ -n "$name" ] || name=$(hostname 2>/dev/null)

--- a/configs/certs/CA/burp_ca.in
+++ b/configs/certs/CA/burp_ca.in
@@ -45,7 +45,16 @@ while ! lock; do
 	fi
 done
 
-name=$(hostname -f 2>/dev/null)
+case "$(uname -s)" init
+	# Solaris derivates don't support 'hostname -f' and, in fact,
+	# set the hostname to '-f' with that call.
+	SunOS)
+		name=$( (check-hostname | cut -d' ' -f7) 2>/dev/null )
+	;;
+	*)
+		name=$(hostname -f 2>/dev/null)
+	;;
+esac
 # Try NetBSD style.
 [ -n "$name" ] || name=$(hostname 2>/dev/null)
 if [ -z "$name" ] ; then


### PR DESCRIPTION
The `hostname` of Solaris and its derivates doesn't support the `-f` option and, in fact, sets the hostname to `-f` if called as root that way. This patch works around that by using the `check-hostname` tool to determine the FQDN of a SunOS host.