### PR TITLE
Add include_fs option (#337)

### DIFF
--- a/manpages/burp.8
+++ b/manpages/burp.8
@@ -662,6 +662,11 @@ Extensions to exclude from compression. Case insensitive. You can have multiple 
 \fBexclude_fs=[fstype]\fR
 File systems to exclude from the backup. Case insensitive. You can have multiple exclude file system lines. For example, set 'tmpfs' to exclude tmpfs. Burp has an internal mapping of file system names to file system IDs. If you know the file system ID, you can use that instead. For example, 'exclude_fs = 0x01021994' will also exclude tmpfs.
 .TP
+\fBinclude_fs=[fstype]\fR
+File systems to include into the backup. Case insensitive. You can have multiple include file system lines. For example, set 'ext4' to include ext4. Burp has an internal mapping of file system names to file system IDs. If you know the file system ID, you can use that instead. For example, 'exclude_fs = 0x01021994' will also include tmpfs. If at least one file system is included, all other filesystems will be excluded per default. Included directories that do not live on an included file system will be skipped, even if \fBcross_all_filesystems\fR is enabled and they contain subdirectories with included file systems.
+
+Note that on SunOS systems \fBinclude_fs\fR and \fBexclude_fs\fR will do a case sensitive compare of the string descriptors of the file systems instead of the numeric IDs (see \fBf_basetype\fR member is \fBstruct statvfs\fR).
+.TP
 \fBmin_file_size=[b/Kb/Mb/Gb]\fR
 Do not back up files that are less than the specified size. Example: 'min_file_size = 10Mb'. Set to 0 (the default) to have no limit.
 .TP

--- a/src/client/find.c
+++ b/src/client/find.c
@@ -59,6 +59,9 @@
 #ifdef HAVE_LINUX_OS
 #include <sys/statfs.h>
 #endif
+#ifdef HAVE_SUN_OS
+#include <sys/statvfs.h>
+#endif
 
 static int (*send_file)(struct asfd *, struct FF_PKT *, struct conf **);
 
@@ -353,20 +356,30 @@ static int found_soft_link(struct asfd *asfd, struct FF_PKT *ff_pkt, struct conf
 	return send_file_w(asfd, ff_pkt, top_level, confs);
 }
 
-static int fstype_excluded(struct asfd *asfd,
-	struct conf **confs, const char *fname)
+static int fstype_matches(struct asfd *asfd,
+	struct conf **confs, const char *fname, int inex)
 {
+#if defined(HAVE_LINUX_OS) \
+ || defined(HAVE_SUN_OS)
+	struct strlist *l;
 #if defined(HAVE_LINUX_OS)
 	struct statfs buf;
-	struct strlist *l;
 	if(statfs(fname, &buf))
+#elif defined(HAVE_SUN_OS)
+	struct statvfs buf;
+	if(statvfs(fname, &buf))
+#endif
 	{
 		logw(asfd, get_cntr(confs), "Could not statfs %s: %s\n",
 			fname, strerror(errno));
 		return -1;
 	}
-	for(l=get_strlist(confs[OPT_EXCFS]); l; l=l->next)
+	for(l=get_strlist(confs[inex]); l; l=l->next)
+#if defined(HAVE_LINUX_OS)
 		if(l->flag==buf.f_type)
+#elif defined(HAVE_SUN_OS)
+		if(strcmp(l->path,buf.f_basetype)==0)
+#endif
 			return -1;
 #endif
 	return 0;
@@ -534,8 +547,13 @@ static int found_directory(struct asfd *asfd,
 #endif
 		))
 	{
-		if(fstype_excluded(asfd, confs, ff_pkt->fname))
+		if(fstype_matches(asfd, confs, ff_pkt->fname, OPT_EXCFS)
+		  || (get_strlist(confs[OPT_INCFS])
+		     && !fstype_matches(asfd, confs, ff_pkt->fname, OPT_INCFS)))
 		{
+			if(top_level)
+				logw(asfd, get_cntr(confs),
+					"Skipping '%s' because of file system include or exclude.\n", fname);
 			ret=send_file_w(asfd, ff_pkt, top_level, confs);
 			goto end;
 		}

--- a/src/conf.c
+++ b/src/conf.c
@@ -749,6 +749,9 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	case OPT_EXCFS:
 	  return sc_lst(c[o], 0,
 		CONF_FLAG_INCEXC|CONF_FLAG_STRLIST_SORTED, "exclude_fs");
+	case OPT_INCFS:
+	  return sc_lst(c[o], 0,
+		CONF_FLAG_INCEXC|CONF_FLAG_STRLIST_SORTED, "include_fs");
 	case OPT_EXCOM:
 	  return sc_lst(c[o], 0,
 		CONF_FLAG_INCEXC|CONF_FLAG_STRLIST_SORTED, "exclude_comp");

--- a/src/conf.h
+++ b/src/conf.h
@@ -155,6 +155,7 @@ enum conf_opt
 	OPT_INCREG, // include (regular expression)
 	OPT_EXCREG, // exclude (regular expression)
 	OPT_EXCFS, // exclude filesystems
+	OPT_INCFS, // include filesystems
 	OPT_EXCOM, // exclude from compression
 	OPT_INCGLOB, // include (glob expression)
 	OPT_CROSS_ALL_FILESYSTEMS,

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -914,11 +914,11 @@ static void set_max_ext(struct strlist *list)
 	if(list) list->flag=max+1;
 }
 
-static int finalise_fstypes(struct conf **c)
+static int finalise_fstypes(struct conf **c, int opt)
 {
 	struct strlist *l;
 	// Set the strlist flag for the excluded fstypes
-	for(l=get_strlist(c[OPT_EXCFS]); l; l=l->next)
+	for(l=get_strlist(c[opt]); l; l=l->next)
 	{
 		l->flag=0;
 		if(!strncasecmp(l->path, "0x", 2))
@@ -962,7 +962,8 @@ static
 int conf_finalise(struct conf **c)
 {
 	int s_script_notify=0;
-	if(finalise_fstypes(c)) return -1;
+	if(finalise_fstypes(c, OPT_EXCFS)) return -1;
+	if(finalise_fstypes(c, OPT_INCFS)) return -1;
 
 	strlist_compile_regexes(get_strlist(c[OPT_INCREG]));
 	strlist_compile_regexes(get_strlist(c[OPT_EXCREG]));

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -177,6 +177,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_INCREG:
 		case OPT_EXCREG:
 		case OPT_EXCFS:
+		case OPT_INCFS:
 		case OPT_EXCOM:
 		case OPT_INCGLOB:
 		case OPT_FIFOS:


### PR DESCRIPTION
Implements #337 and also adds support for `include_fs` and `exclude_fs` for SunOS systems (which use `statvfs` instead of `statfs`; see changes to the manpage).

If an explicit include is skipped because its filesystem was excluded or not included, this also generates a warning now.

Tested under Debian Jessie for Linux and SmartOS for SunOS.