### PR TITLE
Fix for systems lacking lutimes(3) by using utimensat(2)

### DIFF
--- a/src/attribs.c
+++ b/src/attribs.c
@@ -264,12 +264,21 @@ int attribs_set_file_times(struct asfd *asfd,
 	ut.modtime=statp->st_mtime;
 	e=win32_utime(path, &ut);
 #else
+#ifdef HAVE_LUTIMES
 	struct timeval tv[2];
 	tv[0].tv_sec=statp->st_atime;
 	tv[0].tv_usec=0;
 	tv[1].tv_sec=statp->st_mtime;
 	tv[1].tv_usec=0;
 	e=lutimes(path, tv);
+#else
+	struct timespec tv[2];
+	tv[0].tv_sec=statp->st_atime;
+	tv[0].tv_nsec=0;
+	tv[1].tv_sec=statp->st_mtime;
+	tv[1].tv_nsec=0;
+	e=utimensat(AT_FDCWD, path, tv, AT_SYMLINK_NOFOLLOW);
+#endif /* HAVE_LUTIMES */
 #endif
 	if(e<0)
 	{


### PR DESCRIPTION
Wrap the lutimes call in attribs_set_file_times in ifdefs and fall back to using utimensat if we don't have lutimes. We actually need this for AIX support, but this is a general problem because the feature test was missing from this one call to lutimes.

It might be wise to add a feature test to configure, but I don't trust my skills in that matter. IMHO, it should fail in configure phase if neither lutimes nor utimensat could be found.