### PR TITLE
AIX: Complete initial support

### DIFF
--- a/aix/README-7.1-gcc.md
+++ b/aix/README-7.1-gcc.md
@@ -1,0 +1,81 @@
+BURP on IBM AIX 7.1 using GCC
+=============================
+
+This document assumes AIX 7.1 and GCC from Perzl. For more information, visit
+http://perzl.org/aix/index.php?n=Main.Instructions
+
+Packages
+--------
+You need to have the following filesets installed before
+continuing:
+* bos.adt.base
+* bos.adt.include
+* bos.mp64
+* bos.adt.libm
+
+Assitionally, assuming that you are using Perzls RPMs, you need to install the
+IBM Linux toolchain (for rpm support). If you intend to compile uthash into an
+RPM package, you need version 4 of the rpm fileset.
+* libiconv-1.14-3
+* rsync-3.1.2-1
+* libgcc-4.9.3-1
+* info-5.2-2
+* popt-1.16-3
+* librsync-0.9.7-1
+* zlib-1.2.8-1
+* librsync-devel-0.9.7-1
+* tar-1.28-1
+* gdbm-1.9.1-1
+* gmp-6.1.2-1
+* bzip2-1.0.6-1
+* bash_64-4.3-18
+* coreutils-64bit-8.25-2
+* openssl-1.0.1t-1
+* libstdc++-4.9.3-1
+* gcc-4.9.3-1
+* gcc-cpp-4.9.3-1
+* libmpc-1.0.3-1
+* make-4.2.1-1
+* mpfr-3.1.5-1
+* ncurses-5.9-1
+* ncurses-devel-5.9-1
+* zlib-devel-1.2.8-1
+* libtool-2.4.6-1
+* automake-1.15-2
+* autoconf-2.69-2
+* perl-5.8.8-2
+* grep-2.9-1
+* sed-4.3-1
+* m4-1.4.18-1
+* pcre-8.40-1
+* libsigsegv-2.10-1
+* readline-7.0-2
+
+Build Environment
+-----------------
+Setup your build environment like Perzl does for GCC, for ease of use just put this into
+your ~/.bashrc:
+    export CONFIG_SHELL=/opt/freeware/bin/bash
+    export CONFIG_ENV_ARGS=/opt/freeware/bin/bash
+
+    export CC=gcc
+    export CFLAGS="-DSYSV -D_AIX -D_AIX32 -D_AIX41 -D_AIX43 -D_AIX51 -D_AIX52 -D_AIX53 -D_AIX61 -D_AIX71 -D_ALL_SOURCE -DFUNCPROTO=15 -O -I/opt/freeware/include"
+
+    export CXX=g++
+    export CXXFLAGS=$CFLAGS
+
+    export F77=xlf
+    export FFLAGS="-O -I/opt/freeware/include"
+
+    export LD=ld
+    export LDFLAGS="-L/opt/freeware/lib64 -L/opt/freeware/lib -Wl,-blibpath:/opt/freeware/lib64:/opt/freeware/lib:/usr/lib:/lib -Wl,-bmaxdata:0x80000000"
+
+    export PATH=/opt/freeware/bin:/opt/freeware/sbin:/usr/bin:/bin:/etc:/usr/sbin:/usr/ucb:/usr/bin/X11:/sbin:/usr/vac/bin:/usr/vacpp/bin:/usr/ccs/bin:/usr/dt/bin:/usr/opt/perl5/bin::/usr/local/bin:/usr/lib/instl
+
+uthash
+------
+uthash has to be installed manually as there are no RPMs for it for AIX yet. uthash-1.9.9.1 works fine.
+
+Building BURP
+-------------
+Building burp is very straight forward. Just run "./configure", "make" and "make install".

--- a/aix/README-7.1-gcc.md
+++ b/aix/README-7.1-gcc.md
@@ -6,55 +6,70 @@ http://perzl.org/aix/index.php?n=Main.Instructions
 
 Packages
 --------
-You need to have the following filesets installed before
-continuing:
+This section lists the various packages that need to be installed in order to
+build or run burp on an AIX machine.
+
+You need to have the following filesets from IBM installed before continuing:
 * bos.adt.base
 * bos.adt.include
 * bos.mp64
 * bos.adt.libm
 
-Assitionally, assuming that you are using Perzls RPMs, you need to install the
+Additionally, assuming that you are using Perzls RPMs, you need to install the
 IBM Linux toolchain (for rpm support). If you intend to compile uthash into an
-RPM package, you need version 4 of the rpm fileset.
-* libiconv-1.14-3
-* rsync-3.1.2-1
-* libgcc-4.9.3-1
-* info-5.2-2
-* popt-1.16-3
-* librsync-0.9.7-1
-* zlib-1.2.8-1
-* librsync-devel-0.9.7-1
-* tar-1.28-1
-* gdbm-1.9.1-1
-* gmp-6.1.2-1
-* bzip2-1.0.6-1
+RPM package, you need version 4 of the rpm fileset. The following are required
+to build burp, other versions of packages may work too:
+* autoconf-2.69-2
+* automake-1.15-2
 * bash_64-4.3-18
+* bzip2-1.0.6-1
 * coreutils-64bit-8.25-2
-* openssl-1.0.1t-1
-* libstdc++-4.9.3-1
 * gcc-4.9.3-1
 * gcc-cpp-4.9.3-1
+* gdbm-1.9.1-1
+* gmp-6.1.2-1
+* grep-2.9-1
+* info-5.2-2
+* libgcc-4.9.3-1
+* libtool-2.4.6-1
+* libiconv-1.14-3
 * libmpc-1.0.3-1
+* librsync-0.9.7-1
+* librsync-devel-0.9.7-1
+* libsigsegv-2.10-1
+* libstdc++-4.9.3-1
+* m4-1.4.18-1
 * make-4.2.1-1
 * mpfr-3.1.5-1
 * ncurses-5.9-1
 * ncurses-devel-5.9-1
-* zlib-devel-1.2.8-1
-* libtool-2.4.6-1
-* automake-1.15-2
-* autoconf-2.69-2
-* perl-5.8.8-2
-* grep-2.9-1
-* sed-4.3-1
-* m4-1.4.18-1
+* openssl-1.0.1t-1
 * pcre-8.40-1
-* libsigsegv-2.10-1
+* perl-5.8.8-2
+* popt-1.16-3
 * readline-7.0-2
+* rsync-3.1.2-1
+* sed-4.3-1
+* tar-1.28-1
+* zlib-1.2.8-1
+* zlib-devel-1.2.8-1
+
+After that, the following are required to run burp:
+* bash
+* libgcc
+* ncurses
+* mktemp (for burp_ca)
+* libiconv
+* librsync
+* openssl
+* pcre
+* zlib
 
 Build Environment
 -----------------
-Setup your build environment like Perzl does for GCC, for ease of use just put this into
-your ~/.bashrc:
+Setup your build environment like Perzl does for GCC, for ease of use just put
+this into your ~/.bashrc:
+```bash
     export CONFIG_SHELL=/opt/freeware/bin/bash
     export CONFIG_ENV_ARGS=/opt/freeware/bin/bash
 
@@ -71,6 +86,7 @@ your ~/.bashrc:
     export LDFLAGS="-L/opt/freeware/lib64 -L/opt/freeware/lib -Wl,-blibpath:/opt/freeware/lib64:/opt/freeware/lib:/usr/lib:/lib -Wl,-bmaxdata:0x80000000"
 
     export PATH=/opt/freeware/bin:/opt/freeware/sbin:/usr/bin:/bin:/etc:/usr/sbin:/usr/ucb:/usr/bin/X11:/sbin:/usr/vac/bin:/usr/vacpp/bin:/usr/ccs/bin:/usr/dt/bin:/usr/opt/perl5/bin::/usr/local/bin:/usr/lib/instl
+```
 
 uthash
 ------
@@ -81,4 +97,5 @@ Building BURP
 Building burp is very straight forward.
 ./configure --program-prefix= --prefix=/opt/freeware --exec-prefix=/opt/freeware --bindir=/opt/freeware/bin --sbindir=/opt/freeware/sbin --sysconfdir=/etc --datadir=/opt/freeware/share --includedir=/opt/freeware/include --libdir=/opt/freeware/lib --libexecdir=/opt/freeware/libexec --localstatedir=/opt/freeware/var --sharedstatedir=/opt/freeware/com --mandir=/opt/freeware/share/man --infodir=/opt/freeware/share/info --sysconfdir=/etc/burp
 
-Then "make" and "make install".
+Then "make" and "make install". The burp binary will end up in /opt/freeware/sbin, so make sure to add that folder to your PATH or specify a different sbindir.
+

--- a/aix/README-7.1-gcc.md
+++ b/aix/README-7.1-gcc.md
@@ -78,4 +78,7 @@ uthash has to be installed manually as there are no RPMs for it for AIX yet. uth
 
 Building BURP
 -------------
-Building burp is very straight forward. Just run "./configure", "make" and "make install".
+Building burp is very straight forward.
+./configure --program-prefix= --prefix=/opt/freeware --exec-prefix=/opt/freeware --bindir=/opt/freeware/bin --sbindir=/opt/freeware/sbin --sysconfdir=/etc --datadir=/opt/freeware/share --includedir=/opt/freeware/include --libdir=/opt/freeware/lib --libexecdir=/opt/freeware/libexec --localstatedir=/opt/freeware/var --sharedstatedir=/opt/freeware/com --mandir=/opt/freeware/share/man --infodir=/opt/freeware/share/info --sysconfdir=/etc/burp
+
+Then "make" and "make install".

--- a/src/async.c
+++ b/src/async.c
@@ -111,9 +111,25 @@ static int async_io(struct async *as, int doread)
 					as->last_time=as->now;
 					return -1;
 				default:
+#ifdef _AIX
+					/* On AIX, for some weird reason,
+					 * writing the stats file makes the
+					 * socket show up in fse, despite
+					 * everything being fine. We ignore
+					 * it.
+					 */
+					if(strncmp(asfd->desc, "stats file",
+						sizeof("stats file")))
+					{
+						logp("%s: had an exception\n",
+							asfd->desc);
+						return asfd_problem(asfd);
+					}
+#else
 					logp("%s: had an exception\n",
 						asfd->desc);
 					return asfd_problem(asfd);
+#endif /* _AIX */
 			}
 		}
 

--- a/src/burp.h
+++ b/src/burp.h
@@ -139,6 +139,12 @@
 	#define __BIG_ENDIAN    BIG_ENDIAN
 	#define __LITTLE_ENDIAN	LITTLE_ENDIAN
 	#define __PDP_ENDIAN	PDP_ENDIAN
+#elif _AIX && __GNUC__
+	/* AIX is always big endian */
+	#define htobe64(x) (x)
+	#define htole64(x) __builtin_bswap64(x)
+	#define be64toh(x) (x)
+	#define le64toh(x) __builtin_bswap64(x)
 #endif
 
 #if !defined(htobe64) && defined(__GLIBC__) && __GLIBC__ <= 2 && __GLIBC_MINOR__ < 9

--- a/src/client/backup_phase1.c
+++ b/src/client/backup_phase1.c
@@ -156,7 +156,7 @@ static int to_server(struct asfd *asfd, struct conf **confs, struct FF_PKT *ff,
 		ff, sb, cmd, get_int(confs[OPT_COMPRESSION]));
 }
 
-static int send_file(struct asfd *asfd, struct FF_PKT *ff, struct conf **confs)
+static int burp_send_file(struct asfd *asfd, struct FF_PKT *ff, struct conf **confs)
 {
 	static struct sbuf *sb=NULL;
 	struct cntr *cntr=get_cntr(confs);
@@ -239,7 +239,7 @@ int backup_phase1_client(struct asfd *asfd, struct conf **confs)
 		dirsymbol=CMD_DIRECTORY;
 #endif
 
-	if(!(ff=find_files_init(send_file))) goto end;
+	if(!(ff=find_files_init(burp_send_file))) goto end;
 	for(l=get_strlist(confs[OPT_STARTDIR]); l; l=l->next) if(l->flag)
 		if(find_files_begin(asfd, ff, confs, l->path)) goto end;
 	ret=0;

--- a/src/handy.c
+++ b/src/handy.c
@@ -516,7 +516,7 @@ long version_to_long(const char *version)
 	return ret;
 }
 
-/* These receive_a_file() and send_file() functions are for use by extra_comms
+/* These receive_a_file() and burp_send_file() functions are for use by extra_comms
    and the CA stuff, rather than backups/restores. */
 int receive_a_file(struct asfd *asfd, const char *path, struct cntr *cntr)
 {

--- a/src/handy.h
+++ b/src/handy.h
@@ -35,7 +35,7 @@ extern void setup_signal(int sig, void handler(int sig));
 
 extern long version_to_long(const char *version);
 
-/* These receive_a_file() and send_file() functions are for use by extra_comms
+/* These receive_a_file() and burp_send_file() functions are for use by extra_comms
    and the CA stuff, rather than backups/restores. */
 extern int receive_a_file(struct asfd *asfd,
 	const char *path, struct cntr *cntr);

--- a/src/hexmap.c
+++ b/src/hexmap.c
@@ -45,7 +45,7 @@ static void str_to_bytes(const char *str, uint8_t *bytes, size_t len)
 #if BYTE_ORDER == LITTLE_ENDIAN
 		bytes[bpos++] = hexmap1[(uint8_t)str[spos]]
 			| hexmap2[(uint8_t)str[spos+1]];
-#elif BYTE_ORDER == LITTLE_ENDIAN
+#elif BYTE_ORDER == BIG_ENDIAN
 		bytes[bpos-bpos%4+3-bpos%4] = hexmap1[(uint8_t)str[spos]]
 			| hexmap2[(uint8_t)str[spos+1]];
 		bpos+=1;

--- a/src/server/protocol1/restore.c
+++ b/src/server/protocol1/restore.c
@@ -69,7 +69,7 @@ static int inflate_or_link_oldfile(struct asfd *asfd, const char *oldpath,
 	return ret;
 }
 
-static int send_file(struct asfd *asfd, struct sbuf *sb,
+static int burp_send_file(struct asfd *asfd, struct sbuf *sb,
 	int patches, const char *best, struct cntr *cntr)
 {
 	int ret=-1;
@@ -278,7 +278,7 @@ static int process_data_dir_file(struct asfd *asfd,
 	switch(act)
 	{
 		case ACTION_RESTORE:
-			if(send_file(asfd, sb, patches, best, cntr))
+			if(burp_send_file(asfd, sb, patches, best, cntr))
 				goto end;
 			break;
 		case ACTION_VERIFY:

--- a/utest/server/test_auth.c
+++ b/utest/server/test_auth.c
@@ -31,12 +31,11 @@ static struct pdata p[] = {
 	// 1 is success, 0 is failure.
 	{ 1, "hiH9IOyyrrl4k", "ifpqgio" },
 	{ 0, "hiH9IOyyrrl4k", "ifpqgia" },
-#ifndef HAVE_NETBSD_OS
-#ifndef HAVE_DARWIN_OS
+	/* Salt format below is a GNU extension not present on other systems */
+#if !defined(HAVE_NETBSD_OS) && !defined(HAVE_DARWIN_OS) && !defined(_AIX)
 	{ 1, "$6$dYCzeXf3$Vue9VQ49lBLtK7d273FxKYsWrF1WGwr3Th2GBCghj0WG61o/bXxEal/11pCdvWqN/Y1iSiOblqZhitBsqAOVe1", "testuser" },
 	{ 0, "x6$dYCzeXf3$Vue9VQ49lBLtK7d273FxKYsWrF1WGwr3Th2GBCghj0WG61o/bXxEal/11pCdvWqN/Y1iSiOblqZhitBsqAOVe1", "testuser" },
 	{ 0, "x6$dYCzeXf3$Vue9VQ49lBLtK7d273FxKYsWrF1WGwr3Th2GBCghj0WG61o/bXxEal/11pCdvWqN/Y1iSiOblqZhitBsqAOVe1", NULL },
-#endif
 #endif
 	{ 0, NULL, "testuser" },
 	{ 0, "123", "testuser" }


### PR DESCRIPTION
These are the last bits required to get burp working on AIX (see #542)

There are two questionable commits, namely 8ad311a which renames a function that clashes with AIX' standard library and ee87be9 which works around what we suspect to be a platform-specific oddity we weren't able to find the cause for. Our guess is that non-blocking I/O to the local JFS2 filesystem (known to Linux as JFS, by the way) or the way yajl buffer is handled causes this behaviour. The only occurence of the problem is when writing the stats file, everything else works fine.

We've tested so far:
* Protocol 1 only
* Backup (forced and timed) from x86 Linux to a PPC AIX server
* Backup from AIX to AIX
* Restore to an x86 Linux from the PPC AIX server
* Restore to AIX from AIX
* Status monitor on Linux and AIX
* burp_ca (with @chrisv5179 patch)

The test suite still shows a set of errors, though some of them are caused by hard-coded byte values for md5 hashes and then memcmp'ing them.

Regards!