### PR TITLE
More UTF-8 in paths

### DIFF
--- a/src/burp.h
+++ b/src/burp.h
@@ -77,12 +77,12 @@
 // Local Burp includes. Be sure to put all the system includes before these.
 #ifdef HAVE_WIN32
 	#include <windows.h>
-	#include "win32/compat/compat.h"
 #endif
 
 #include "burpconfig.h"
 
 #ifdef HAVE_WIN32
+	#include "win32/compat/compat.h"
 	#include "win32/winapi.h"
 	#include "winhost.h"
 #endif

--- a/src/burpconfig.h
+++ b/src/burpconfig.h
@@ -7,6 +7,24 @@
 #define ASSERT(x)
 
 #ifdef HAVE_WIN32
+
+// unicode enabling of win 32 needs some defines and functions
+
+// using an average of 3 bytes per character is probably fine in
+// practice but I believe that Windows actually uses UTF-16 encoding
+// as opposed to UCS2 which means characters 0x10000-0x10ffff are
+// valid and result in 4 byte UTF-8 encodings.
+#define MAX_PATH_UTF8    MAX_PATH*4  // strict upper bound on UTF-16 to UTF-8 conversion
+
+// from
+// http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/getfileattributesex.asp
+// In the ANSI version of this function, the name is limited to
+// MAX_PATH characters. To extend this limit to 32,767 wide
+// characters, call the Unicode version of the function and prepend
+// "\\?\" to the path. For more information, see Naming a File.
+#define MAX_PATH_W 32767
+
+
 	#define WIN32_REPARSE_POINT  1 // Any odd dir except the next two.
 	#define WIN32_MOUNT_POINT    2 // Directory link to Volume.
 	#define WIN32_JUNCTION_POINT 3 // Directory link to a directory.
@@ -24,8 +42,8 @@
 	#endif
 #endif
 
-#ifndef S_ISLNK
-#define S_ISLNK(m) (((m) & S_IFM) == S_IFLNK)
+#ifdef S_IFLNK
+#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
 #endif
 
 #ifndef O_BINARY

--- a/src/burpconfig.h
+++ b/src/burpconfig.h
@@ -6,7 +6,17 @@
 
 #define ASSERT(x)
 
-#ifdef HAVE_WIN32
+// MAX_PATH is Windows constatnt, usually 260, maybe changed in some Win10 update.
+// PATH_MAX is Posix constant
+// right method - it to call pathconf(), but such case lead to reworking lots of code;
+// and some buffers are better to allocate on stack, not on heap
+#ifndef MAX_PATH
+    #ifdef PATH_MAX
+        #define MAX_PATH           PATH_MAX
+    #else
+        #define MAX_PATH           260
+    #endif
+#endif
 
 // unicode enabling of win 32 needs some defines and functions
 
@@ -24,6 +34,7 @@
 // "\\?\" to the path. For more information, see Naming a File.
 #define MAX_PATH_W 32767
 
+#ifdef HAVE_WIN32
 
 	#define WIN32_REPARSE_POINT  1 // Any odd dir except the next two.
 	#define WIN32_MOUNT_POINT    2 // Directory link to Volume.

--- a/src/burpconfig.h
+++ b/src/burpconfig.h
@@ -42,10 +42,6 @@
 	#endif
 #endif
 
-#ifdef S_IFLNK
-#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
-#endif
-
 #ifndef O_BINARY
 	#define O_BINARY 0
 #endif

--- a/src/log.c
+++ b/src/log.c
@@ -48,7 +48,7 @@ void logp(const char *fmt, ...)
 {
 #ifndef UTEST
 	int pid;
-	char buf[512]="";
+	char buf[512+MAX_PATH_UTF8]="";
 	va_list ap;
 	va_start(ap, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, ap);
@@ -228,7 +228,7 @@ void log_restore_settings(struct conf **cconfs, int srestore)
 int logm(struct asfd *asfd, struct conf **confs, const char *fmt, ...)
 {
 	int r=0;
-	char buf[512]="";
+	char buf[512+MAX_PATH_UTF8]="";
 	va_list ap;
 	va_start(ap, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, ap);
@@ -248,7 +248,7 @@ int logm(struct asfd *asfd, struct conf **confs, const char *fmt, ...)
 int logw(struct asfd *asfd, struct cntr *cntr, const char *fmt, ...)
 {
 	int r=0;
-	char buf[512]="";
+	char buf[512+MAX_PATH_UTF8]="";
 	va_list ap;
 	va_start(ap, fmt);
 	vsnprintf(buf, sizeof(buf), fmt, ap);

--- a/src/server/protocol1/backup_phase2.c
+++ b/src/server/protocol1/backup_phase2.c
@@ -46,7 +46,7 @@ static int path_too_long(struct iobuf *path, struct conf **cconfs)
 		return path_length_warn(path, cconfs);
 	}
 	// We have to check every part in the path to ensure it less then fs_name_max
-	// minimum windows case is c:/a, nix case is /a
+	// minimum windows case is c:/a, nix case is /
 	// usual: c:/users, /home
 	cp = strchr(path->buf, '/');
 	if( !cp ) // very strange
@@ -942,6 +942,7 @@ static int process_next_file_from_manios(struct asfd *asfd,
 			sdirs, cb, *p1b, ucmanio, hmanio, cconfs))
 		{
 			case P_NEW:
+				return 0;
 			case P_CHANGED:
 				// Free cb content for things like encrypted
 				// files, which we only pretend are new.
@@ -985,6 +986,7 @@ static int process_next_file_from_manios(struct asfd *asfd,
 			cb, *p1b, ucmanio, hmanio, cconfs))
 		{
 			case P_NEW:
+				return 0;
 			case P_CHANGED:
 				// Free cb content for things like encrypted
 				// files, which we only pretend are new.

--- a/src/server/protocol1/backup_phase2.c
+++ b/src/server/protocol1/backup_phase2.c
@@ -31,7 +31,10 @@ static int path_length_warn(struct iobuf *path, struct conf **cconfs)
 
 static int path_too_long(struct iobuf *path, struct conf **cconfs)
 {
-	static const char *cp;
+	const char *cp;
+	const char *cp1; 
+	size_t len;
+
 	if(treepathlen+path->len+1>fs_full_path_max)
 	{
 		// FIX THIS:
@@ -42,9 +45,21 @@ static int path_too_long(struct iobuf *path, struct conf **cconfs)
 		// to be able to fix it.
 		return path_length_warn(path, cconfs);
 	}
-	if((cp=strrchr(path->buf, '/'))) cp++;
-	else cp=path->buf;
-	if(strlen(cp)>fs_name_max) return path_length_warn(path, cconfs);
+	// We have to check every part in the path to ensure it less then fs_name_max
+	// minimum windows case is c:/a, nix case is /a
+	// usual: c:/users, /home
+	cp = strchr(path->buf, '/');
+	if( !cp ) // very strange
+	    return strlen(path->buf) > fs_name_max ?  path_length_warn(path, cconfs):0;
+	while(cp && *cp)
+	{
+	    cp++;
+	    cp1 = strchr(cp, '/');
+	    len = cp1? cp1-cp : strlen(cp);
+	    if( len > fs_name_max ) 
+		return path_length_warn(path, cconfs);
+	    cp = cp1;
+	}
 	return 0;
 }
 

--- a/src/server/protocol1/bedup.c
+++ b/src/server/protocol1/bedup.c
@@ -605,7 +605,7 @@ static int process_dir(const char *oldpath, const char *newpath,
 	}
 	ret=0;
 end:
-	closedir(dirp);
+	if(dirp) closedir(dirp);
 	free_w(&newfile.path);
 	free_w(&path);
 	return ret;

--- a/src/win32/Makefile
+++ b/src/win32/Makefile
@@ -61,8 +61,8 @@ $(DIRS):
 			exit 1 ; \
 		fi ; \
 	done ; \
-	ln -vsfT $${TOOLSDIR}/burp-cross-tools ../../burp-cross-tools ; \
-	ln -vsfT $${TOOLSDIR}/burp-depkgs ../../burp-depkgs
+	ln -vsf $${TOOLSDIR}/burp-cross-tools ../../burp-cross-tools ; \
+	ln -vsf $${TOOLSDIR}/burp-depkgs ../../burp-depkgs
 
 Makefile.inc: ../../burp-cross-tools
 	@echo Creating $@

--- a/src/win32/compat/compat.h
+++ b/src/win32/compat/compat.h
@@ -137,7 +137,7 @@ struct dirent
 	uint64_t d_ino;
 	uint32_t d_off;
 	uint16_t d_reclen;
-	char d_name[MAX_PATH];
+	char d_name[MAX_PATH_UTF8];
 };
 typedef void DIR;
 

--- a/src/win32/winapi.h
+++ b/src/win32/winapi.h
@@ -41,19 +41,9 @@
 
 // unicode enabling of win 32 needs some defines and functions
 
-// using an average of 3 bytes per character is probably fine in
-// practice but I believe that Windows actually uses UTF-16 encoding
-// as opposed to UCS2 which means characters 0x10000-0x10ffff are
-// valid and result in 4 byte UTF-8 encodings.
-#define MAX_PATH_UTF8    MAX_PATH*4  // strict upper bound on UTF-16 to UTF-8 conversion
-
-// from
-// http://msdn.microsoft.com/library/default.asp?url=/library/en-us/fileio/fs/getfileattributesex.asp
-// In the ANSI version of this function, the name is limited to
-// MAX_PATH characters. To extend this limit to 32,767 wide
-// characters, call the Unicode version of the function and prepend
-// "\\?\" to the path. For more information, see Naming a File.
-#define MAX_PATH_W 32767
+// MAX_PATH_UTF8 moved to burpconfig.h
+// winapi.h used only in burp.h just after using burpconfig.h
+#include "burpconfig.h"
 
 int wchar_2_UTF8(char *pszUTF, const WCHAR *pszUCS, int cchChar = MAX_PATH_UTF8);
 int UTF8_2_wchar(char **pszUCS, const char *pszUTF);


### PR DESCRIPTION
More UTF-8 in paths, in logging functions,

Make compat.cpp/copyin safe for buffer size.

S_ISLNK  is defined in compat.h, so it's useless in burpconfig.h

Patch for makefile is for FreeBSD, it's 'ln' has no '-T' option.

Fix bedup failed in empty directories. 