### PR TITLE
add the ability to reset strlists through the special ':=' syntax

### DIFF
--- a/src/client/ca.c
+++ b/src/client/ca.c
@@ -77,10 +77,11 @@ static int rewrite_client_conf(struct conf **confs)
 		char *copy=NULL;
 		char *field=NULL;
 		char *value=NULL;
+		int r=0;
 
 		if(!(copy=strdup_w(buf, __func__)))
 			goto end;
-		if(conf_get_pair(buf, &field, &value)
+		if(conf_get_pair(buf, &field, &value, &r)
 		  || !field || !value
 		  || strcmp(field, "ssl_peer_cn"))
 		{

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -62,7 +62,7 @@ static int remove_quotes(const char *f, char **v, char quote)
 }
 
 // Get field and value pair.
-int conf_get_pair(char buf[], char **f, char **v)
+int conf_get_pair(char buf[], char **f, char **v, int *r)
 {
 	char *cp=NULL;
 	char *eq=NULL;
@@ -80,7 +80,11 @@ int conf_get_pair(char buf[], char **f, char **v)
 	*eq='\0';
 
 	// Strip white space from before the equals sign.
-	for(cp=eq-1; *cp && isspace(*cp); cp--) *cp='\0';
+	for(cp=eq-1; *cp && (isspace(*cp) || *cp == ':'); cp--)
+	{
+		if(*cp == ':') *r=1;
+		*cp='\0';
+	}
 	// Skip white space after the equals sign.
 	for(cp=eq+1; *cp && isspace(*cp); cp++) { }
 	*v=cp;
@@ -233,6 +237,7 @@ static int get_compression(const char *v)
 static int load_conf_field_and_value(struct conf **c,
 	const char *f, // field
 	const char *v, // value
+	int reset, // reset flag
 	const char *conf_path,
 	int line)
 {
@@ -297,6 +302,7 @@ static int load_conf_field_and_value(struct conf **c,
 					return set_e_recovery_method(c[i],
 						str_to_recovery_method(v));
 				case CT_STRLIST:
+					if (reset) set_strlist(c[i], 0);
 					return add_to_strlist(c[i], v,
 					  !strcmp(c[i]->field, "include"));
 				case CT_E_RSHASH:
@@ -364,6 +370,7 @@ static int conf_parse_line(struct conf **confs, const char *conf_path,
 	char buf[], int line)
 {
 	int ret=-1;
+	int r=0;
 	char *f=NULL; // field
 	char *v=NULL; // value
 	char *extrafile=NULL;
@@ -382,9 +389,9 @@ static int conf_parse_line(struct conf **confs, const char *conf_path,
 		goto end;
 	}
 
-	if(conf_get_pair(buf, &f, &v)) goto end;
+	if(conf_get_pair(buf, &f, &v, &r)) goto end;
 	if(f && v
-	  && load_conf_field_and_value(confs, f, v, conf_path, line))
+	  && load_conf_field_and_value(confs, f, v, r, conf_path, line))
 		goto end;
 	ret=0;
 end:

--- a/src/conffile.h
+++ b/src/conffile.h
@@ -4,7 +4,7 @@
 #include "cntr.h"
 #include "strlist.h"
 
-extern int conf_get_pair(char buf[], char **field, char **value);
+extern int conf_get_pair(char buf[], char **field, char **value, int *reset);
 extern int conf_parse_incexcs_buf(struct conf **confs, const char *incexc);
 extern int conf_parse_incexcs_path(struct conf **confs, const char *path);
 

--- a/src/server/ca.c
+++ b/src/server/ca.c
@@ -20,6 +20,7 @@ static char *get_ca_dir(const char *ca_conf)
 	struct fzp *fzp=NULL;
 	char buf[4096]="";
 	char *ca_dir=NULL;
+	int r=0;
 
 	if(!(fzp=fzp_open(ca_conf, "r")))
 		goto end;
@@ -27,7 +28,7 @@ static char *get_ca_dir(const char *ca_conf)
 	{
 		char *field=NULL;
 		char *value=NULL;
-		if(conf_get_pair(buf, &field, &value)
+		if(conf_get_pair(buf, &field, &value, &r)
 		  || !field || !value) continue;
 
 		if(!strcasecmp(field, "CA_DIR"))


### PR DESCRIPTION
Hello,

While working on a new way to package burp (in order to ease the *burp-contrib* integration) I thought it would be great to have the ability to *reset* strlists through a special syntax using `:=` instead of `=`.

Here is the idea:

```
$ cat /etc/burp/burp-server.conf
[...]
timer_script = default_timer_script.sh
timer_arg = arg1
timer_arg = arg2
[...]
. /etc/burp/conf.d/*.conf
$ cat /etc/burp/conf.d/timer.conf
timer_script = contrib_timer_script.sh
timer_arg = myarg1
timer_arg = myarg2
```

So the `burp-server` package ships with this */etc/burp/burp-server.conf* config which is *include* ready thanks to the `. /etc/burp/conf.d/*.conf` line.

Now the `burp-contrib` package ships with the */etc/burp/conf.d/timer.conf* file which aims to provide `timer_script` config.

The problem is, before the patch, there is no way to ignore previously setup `timer_arg`s so the resulting `timer_arg` list would contain `['arg1', 'arg2', 'myarg1', 'myarg2']`.

With the patch, we can now have:

```
$ cat /etc/burp/conf.d/timer.conf
timer_script = contrib_timer_script.sh
timer_arg := myarg1
timer_arg = myarg2
```

And the resulting `timer_arg` list will contain `['myarg1', 'myarg2']`.