### PR TITLE
fix: missing globfree

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -351,6 +351,8 @@ static int deal_with_dot_inclusion(const char *conf_path,
 	for(i=0; (unsigned int)i<globbuf.gl_pathc; i++)
 		if((ret=conf_load_lines_from_file(globbuf.gl_pathv[i], confs)))
 			goto end;
+
+	globfree(&globbuf);
 #else
 	ret=conf_load_lines_from_file(*extrafile, confs);
 #endif


### PR DESCRIPTION
Hello,

While running some tests upon the #572 changes, I noticed a memory leak with the glob config inclusion in conffile.c.

Before the patch, valgrind would report something like:

```
==24106==
==24106== HEAP SUMMARY:
==24106==     in use at exit: 79 bytes in 3 blocks
==24106==   total heap usage: 391 allocs, 388 frees, 85,010 bytes allocated
==24106==
==24106== 79 (24 direct, 55 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 2
==24106==    at 0x4C28C20: malloc (vg_replace_malloc.c:296)
==24106==    by 0x4C2AFCF: realloc (vg_replace_malloc.c:692)
==24106==    by 0x62FEA40: glob_in_dir (glob.c:1677)
==24106==    by 0x62FF9C9: glob (glob.c:1220)
==24106==    by 0x40FA2C: deal_with_dot_inclusion (conffile.c:356)
==24106==    by 0x40FA2C: conf_parse_line (conffile.c:388)
==24106==    by 0x40FEE7: conf_load_lines_from_file (conffile.c:1133)
==24106==    by 0x4104B1: do_load_global_only (conffile.c:1366)
==24106==    by 0x4104B1: conf_load_global_only (conffile.c:1376)
==24106==    by 0x416DBF: reload (prog.c:99)
==24106==    by 0x40697C: real_main (prog.c:405)
==24106==    by 0x40697C: main (prog.c:531)
==24106==
==24106== LEAK SUMMARY:
==24106==    definitely lost: 24 bytes in 1 blocks
==24106==    indirectly lost: 55 bytes in 2 blocks
==24106==      possibly lost: 0 bytes in 0 blocks
==24106==    still reachable: 0 bytes in 0 blocks
==24106==         suppressed: 0 bytes in 0 blocks
==24106==
==24106== For counts of detected and suppressed errors, rerun with: -v
==24106== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

After the patch it returns:

```
==24786== 
==24786== HEAP SUMMARY:
==24786==     in use at exit: 0 bytes in 0 blocks
==24786==   total heap usage: 391 allocs, 391 frees, 85,010 bytes allocated
==24786== 
==24786== All heap blocks were freed -- no leaks are possible
==24786== 
==24786== For counts of detected and suppressed errors, rerun with: -v
==24786== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```