### PR TITLE
Fix segfault when sb->link.buf is NULL

### DIFF
--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -667,7 +667,7 @@ int do_restore_client(struct asfd *asfd,
 					strip_from_path(sb->path.buf,
 						strip_path);
 					// Strip links if their path is absolute
-					if(!is_absolute(sb->link.buf))
+					if(sb->link.buf && !is_absolute(sb->link.buf))
 						strip_from_path(sb->link.buf,
 							strip_path);
 				}


### PR DESCRIPTION
When `stripfrompath` is defined, `src/client/restore.c:is_absolute()` causes a segfault with the first `sb->link.buf` that is NULL. This fixes that.