### PR TITLE
Adds proper key-derivation (and IV) for client encryption

### DIFF
--- a/configs/client/burp.conf.in
+++ b/configs/client/burp.conf.in
@@ -42,6 +42,10 @@ server_can_restore = 0
 # Note that this will mean that network deltas will not be possible. Each time
 # a file changes, the whole file will be transferred on the next backup.
 # encryption_password = My^$pAsswIrD%@
+# By default, legacy encryption is enabled (hard-coded IV, passphrase
+# used directly as key).  Unless your backups are already encrypted
+# with the old method, it is recommended you uncomment this line.
+# key_derivation = 1
 
 # More configuration files can be read, using syntax like the following
 # (without the leading '# ').

--- a/src/client/protocol1/backup_phase2.c
+++ b/src/client/protocol1/backup_phase2.c
@@ -149,11 +149,12 @@ static enum send_e send_whole_file_w(struct asfd *asfd,
 	struct sbuf *sb, const char *datapth,
 	int quick_read, uint64_t *bytes, const char *encpassword,
 	struct cntr *cntr, int compression, struct BFILE *bfd,
-	const char *extrameta, size_t elen)
+	const char *extrameta, size_t elen, int key_deriv)
 {
 	if((compression || encpassword) && sb->path.cmd!=CMD_EFS_FILE)
 		return send_whole_file_gzl(asfd, datapth, quick_read, bytes,
-		  encpassword, cntr, compression, bfd, extrameta, elen);
+		  encpassword, cntr, compression, bfd, extrameta, elen,
+		  key_deriv);
 	else
 		return send_whole_filel(asfd,
 #ifdef HAVE_WIN32
@@ -319,7 +320,7 @@ static int deal_with_data(struct asfd *asfd, struct sbuf *sb,
 		switch(send_whole_file_w(asfd, sb, NULL, 0, &bytes,
 			get_string(confs[OPT_ENCRYPTION_PASSWORD]),
 			cntr, sb->compression,
-			bfd, extrameta, elen))
+			bfd, extrameta, elen, get_int(confs[OPT_KEY_DERIVATION])))
 		{
 			case SEND_OK:
 			case SEND_ERROR: // Carry on.

--- a/src/client/protocol1/restore.h
+++ b/src/client/protocol1/restore.h
@@ -4,6 +4,7 @@
 int restore_switch_protocol1(struct asfd *asfd, struct sbuf *sb,
 	const char *fullpath, enum action act,
 	struct BFILE *bfd, int vss_restore, struct cntr *cntr,
-	const char *encryption_password);
+	const char *encryption_password,
+	int key_deriv);
 
 #endif

--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -739,7 +739,8 @@ int do_restore_client(struct asfd *asfd,
 		else
 		{
 			if(restore_switch_protocol1(asfd, sb, fullpath, act,
-				bfd, vss_restore, cntr, encryption_password))
+				bfd, vss_restore, cntr, encryption_password,
+				get_int(confs[OPT_KEY_DERIVATION])))
 					goto error;
 		}
 	}

--- a/src/conf.c
+++ b/src/conf.c
@@ -488,6 +488,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_str(c[o], 0, 0, "server");
 	case OPT_ENCRYPTION_PASSWORD:
 	  return sc_str(c[o], 0, 0, "encryption_password");
+	case OPT_KEY_DERIVATION:
+	  return sc_int(c[o], 0, 0, "key_derivation");
 	case OPT_AUTOUPGRADE_OS:
 	  return sc_str(c[o], 0, 0, "autoupgrade_os");
 	case OPT_AUTOUPGRADE_DIR:

--- a/src/conf.h
+++ b/src/conf.h
@@ -142,6 +142,7 @@ enum conf_opt
 	OPT_ENABLED, // also a clientconfdir option
 	OPT_SERVER,
 	OPT_ENCRYPTION_PASSWORD,
+	OPT_KEY_DERIVATION,
 	OPT_AUTOUPGRADE_OS,
 	OPT_AUTOUPGRADE_DIR, // also a server option
 	OPT_CA_CSR_DIR,

--- a/src/protocol1/handy.h
+++ b/src/protocol1/handy.h
@@ -21,7 +21,7 @@ enum send_e
 extern enum send_e send_whole_file_gzl(struct asfd *asfd, const char *datapth,
 	int quick_read, uint64_t *bytes, const char *encpassword,
 	struct cntr *cntr, int compression, struct BFILE *bfd,
-	const char *extrameta, size_t elen);
+	const char *extrameta, size_t elen, int key_deriv);
 
 extern enum send_e send_whole_filel(struct asfd *asfd,
 #ifdef HAVE_WIN32
@@ -32,7 +32,8 @@ extern enum send_e send_whole_filel(struct asfd *asfd,
 	struct BFILE *bfd,
 	const char *extrameta, size_t elen);
 
-extern EVP_CIPHER_CTX *enc_setup(int encrypt, const char *encryption_password);
+extern EVP_CIPHER_CTX *enc_setup(int encrypt, const char *encryption_password,
+	int key_deriv);
 
 extern char *get_endfile_str(uint64_t bytes, uint8_t *checksum);
 extern int write_endfile(struct asfd *asfd, uint64_t bytes, uint8_t *checksum);

--- a/src/protocol1/msg.c
+++ b/src/protocol1/msg.c
@@ -174,7 +174,7 @@ int transfer_gzfile_inl(struct asfd *asfd,
 	struct BFILE *bfd,
 	uint64_t *rcvd, uint64_t *sent,
 	const char *encpassword, int enccompressed,
-	struct cntr *cntr, char **metadata)
+	struct cntr *cntr, char **metadata, int key_deriv)
 {
 	int quit=0;
 	int ret=-1;
@@ -215,7 +215,7 @@ int transfer_gzfile_inl(struct asfd *asfd,
 		return -1;
 	}
 
-	if(encpassword && !(enc_ctx=enc_setup(0, encpassword)))
+	if(encpassword && !(enc_ctx=enc_setup(0, encpassword, key_deriv)))
 	{
 		inflateEnd(&zstrm);
 		return -1;

--- a/src/protocol1/msg.h
+++ b/src/protocol1/msg.h
@@ -10,6 +10,7 @@ extern int transfer_gzfile_inl(struct asfd *asfd,
 #endif
 	struct BFILE *bfd,
 	uint64_t *rcvd, uint64_t *sent, const char *encpassword,
-	int enccompressed, struct cntr *cntr, char **metadata);
+	int enccompressed, struct cntr *cntr, char **metadata,
+	int key_deriv);
 
 #endif

--- a/src/server/protocol1/restore.c
+++ b/src/server/protocol1/restore.c
@@ -70,7 +70,7 @@ static int inflate_or_link_oldfile(struct asfd *asfd, const char *oldpath,
 }
 
 static int burp_send_file(struct asfd *asfd, struct sbuf *sb,
-	int patches, const char *best, struct cntr *cntr)
+	int patches, const char *best, struct cntr *cntr, int key_deriv)
 {
 	enum send_e ret=SEND_FATAL;
 	struct BFILE bfd;
@@ -87,7 +87,7 @@ static int burp_send_file(struct asfd *asfd, struct sbuf *sb,
 		// If we did some patches, the resulting file
 		// is not gzipped. Gzip it during the send.
 		ret=send_whole_file_gzl(asfd, sb->protocol1->datapth.buf,
-			1, &bytes, NULL, cntr, 9, &bfd, NULL, 0);
+			1, &bytes, NULL, cntr, 9, &bfd, NULL, 0, key_deriv);
 	}
 	else
 	{
@@ -111,7 +111,7 @@ static int burp_send_file(struct asfd *asfd, struct sbuf *sb,
 		{
 			ret=send_whole_file_gzl(asfd,
 				sb->protocol1->datapth.buf, 1, &bytes,
-				NULL, cntr, 9, &bfd, NULL, 0);
+				NULL, cntr, 9, &bfd, NULL, 0, key_deriv);
 		}
 		else
 		{
@@ -287,7 +287,8 @@ static int process_data_dir_file(struct asfd *asfd,
 	switch(act)
 	{
 		case ACTION_RESTORE:
-			if(burp_send_file(asfd, sb, patches, best, cntr))
+			if(burp_send_file(asfd, sb, patches, best, cntr,
+					  get_int(cconfs[OPT_KEY_DERIVATION])))
 				goto end;
 			break;
 		case ACTION_VERIFY:

--- a/utest/protocol1/test_handy.c
+++ b/utest/protocol1/test_handy.c
@@ -9,7 +9,7 @@ static void tear_down(void)
 
 START_TEST(test_enc_setup_no_password)
 {
-	fail_unless(enc_setup(1 /*encrypt*/, NULL)==NULL);
+	fail_unless(enc_setup(1 /*encrypt*/, NULL, 1)==NULL);
 	tear_down();
 }
 END_TEST
@@ -17,7 +17,7 @@ END_TEST
 START_TEST(test_enc_setup_ok)
 {
 	EVP_CIPHER_CTX *ctx;
-	fail_unless((ctx=enc_setup(1 /*encrypt*/, "somepass"))!=NULL);
+	fail_unless((ctx=enc_setup(1 /*encrypt*/, "somepass", 1))!=NULL);
 	EVP_CIPHER_CTX_cleanup(ctx);
 	EVP_CIPHER_CTX_free(ctx);
 	tear_down();


### PR DESCRIPTION
This commit adds support to use OpenSSL's EVP BytesToKey to generate
the key for client encryption.  This also deals with the problem of
the hard-coded IV.

In order to ensure backwards-compatibility with encryption made before
this change, the config option to enabled this feature is off by
default.  This example config strongly encourages the user to enable
it if they are making their first backup.

I'm not very familiar with burp's code, so please let me know if I've
done anything wrong and I'll get right on it.

This fixes #588.