### PR TITLE
Use pkg-config to detect ncurses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -285,7 +285,19 @@ m4_ifdef([PKG_CHECK_MODULES],
        CFLAGS="$CFLAGS $ncurses_CFLAGS -DHAVE_NCURSES_H=1"
        AC_DEFINE([HAVE_NCURSES], [1], [Set to 1 if we have ncurses])
       ],
-      []
+      [
+       AC_CHECK_HEADERS([ncurses.h ncurses/ncurses.h],
+         [
+           AC_CHECK_LIB([ncurses], [curs_set],
+             [
+               NCURSES_LIBS="-lncurses"
+               have_ncurses=yes
+               AC_DEFINE([HAVE_NCURSES], [1], [Set to 1 if we have ncurses])
+             ]
+           )
+         ]
+       )
+      ]
     )
   ]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -276,14 +276,16 @@ dnl Check whether libncurses is available
 dnl -----------------------------------------------------------
 
 have_ncurses=no
-AC_CHECK_HEADERS([ncurses.h ncurses/ncurses.h],
+m4_ifdef([PKG_CHECK_MODULES],
   [
-    AC_CHECK_LIB([ncurses], [curs_set],
+    PKG_CHECK_MODULES([ncurses], [ncurses],
       [
-        NCURSES_LIBS="-lncurses"
-        have_ncurses=yes
-        AC_DEFINE([HAVE_NCURSES], [1], [Set to 1 if we have ncurses])
-      ]
+       have_ncurses=yes
+       NCURSES_LIBS="$ncurses_LIBS"
+       CFLAGS="$CFLAGS $ncurses_CFLAGS -DHAVE_NCURSES_H=1"
+       AC_DEFINE([HAVE_NCURSES], [1], [Set to 1 if we have ncurses])
+      ],
+      []
     )
   ]
 )


### PR DESCRIPTION
Ncurses can be built split into libncurses proper and libtinfo. The old
check looked inside libncurses for a symbol which in case of a split
build appears in libtinfo, resulting in ncurses support in burp being
incorrectly disabled.

Seeing as burp already uses pkg-config to detect Check, use it. This
takes care of the split-library scenario and also makes it possible to
get rid of all the #ifdef HAVE_NCURSES_H ... #elif
HAVE_NCURSES_NCURSES_H ... #endif bits from the code - a simple #ifdef
HAVE_NCURSES ought to work.