### PR TITLE
Fix burp service file for RHEL / CentOS 7

### DIFF
--- a/rhel/SOURCES/burp.service
+++ b/rhel/SOURCES/burp.service
@@ -3,7 +3,7 @@ Description=Burp backup server
 After=network.target
 
 [Service]
-Type=notify
+Type=forking
 ExecStart=/usr/sbin/burp -c /etc/burp/burp-server.conf
 
 [Install]


### PR DESCRIPTION
Since burp forks without -F parameter, type should be forking.