### PR TITLE
Fix buffer overrun and slightly refactor xstrsplit in glob_windows.c

### DIFF
--- a/src/client/glob_windows.c
+++ b/src/client/glob_windows.c
@@ -30,43 +30,30 @@ static void xfree_list(char **list, int size)
  */
 static char **xstrsplit(const char *src, const char *delimiters, size_t *size)
 {
-	int n=1;
-	char *tmp;
+	size_t allocated;
 	char *init=NULL;
 	char **ret=NULL;
 
 	*size=0;
 	if(!(init=strdup_w(src, __func__))) goto end;
-	if(!(tmp=strtok(init, delimiters)))
-	{
-		logp("Found no tokens from %s in %s\n", init, __func__);
+	if(!(ret=(char **)malloc_w((allocated=10)*sizeof(char *), __func__)))
 		goto end;
-	}
-	if(!(ret=(char **)calloc_w(10, sizeof(char *), __func__)))
-		goto end;
-	while(tmp)
+	for(char *tmp=strtok(init, delimiters); tmp; tmp=strtok(NULL, delimiters))
 	{
-		if((int)*size>n*10)
+		// Check if space is present for another token and terminating NULL.
+		if(allocated<*size+2)
 		{
 			if(!(ret=(char **)realloc_w(ret,
-				n++*10*sizeof(char *), __func__)))
+				(allocated=*size+11)*sizeof(char *), __func__)))
 					return NULL;
 		}
-		if(!(ret[*size]=strdup_w(tmp, __func__)))
+		if(!(ret[(*size)++]=strdup_w(tmp, __func__)))
 		{
 			ret=NULL;
 			goto end;
 		}
-		tmp=strtok(NULL, delimiters);
-		(*size)++;
 	}
-	if((int)*size+1>n*10)
-	{
-		if(!(ret=(char **)realloc_w(ret,
-			(n*10+1)*sizeof(char *), __func__)))
-				return NULL;
-	}
-	ret[*size+1]=NULL;
+	ret[*size]=NULL;
 
 end:
 	free_w(&init);

--- a/src/client/glob_windows.c
+++ b/src/client/glob_windows.c
@@ -21,6 +21,13 @@ static void xfree_list(char **list, int size)
 	free_w(list);
 }
 
+/*
+ * Returns NULL-terminated list of tokens found in string src,
+ * also sets *size to number of tokens found (list length without final NULL).
+ * On failure returns NULL. List itself and tokens are dynamically allocated.
+ * Calls to strtok with delimiters in second argument are used (see its docs),
+ * but neither src nor delimiters arguments are altered.
+ */
 static char **xstrsplit(const char *src, const char *delimiters, size_t *size)
 {
 	int n=1;

--- a/src/client/glob_windows.c
+++ b/src/client/glob_windows.c
@@ -21,7 +21,7 @@ static void xfree_list(char **list, int size)
 	free_w(list);
 }
 
-static char **xstrsplit(const char *src, const char *token, size_t *size)
+static char **xstrsplit(const char *src, const char *delimiters, size_t *size)
 {
 	int n=1;
 	char *tmp;
@@ -30,7 +30,7 @@ static char **xstrsplit(const char *src, const char *token, size_t *size)
 
 	*size=0;
 	if(!(init=strdup_w(src, __func__))) goto end;
-	if(!(tmp=strtok(init, token)))
+	if(!(tmp=strtok(init, delimiters)))
 	{
 		logp("Found no tokens from %s in %s\n", init, __func__);
 		goto end;
@@ -50,7 +50,7 @@ static char **xstrsplit(const char *src, const char *token, size_t *size)
 			ret=NULL;
 			goto end;
 		}
-		tmp=strtok(NULL, token);
+		tmp=strtok(NULL, delimiters);
 		(*size)++;
 	}
 	if((int)*size+1>n*10)


### PR DESCRIPTION
Fix following problems in static function `xstrsplit` defined in `src/client/glob_windows.c`:
- buffer expansion allocates 10 items less than it thinks it does (`n++` in place of `++n`);
- off-by-one error when checking if `ret` buffer must be expanded (in two places);
- off-by-one error in placement of terminating `NULL`;
- delimiters argument confusingly called `tokens`;
- not clear what function should do (added comment);
- zero tokens case was processed specially and caused function to fail (why?).

Particularly, before this patch burp crashed while processing the following configuration line:
```
include_glob = C:\*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_
```
Even though more than one globbing character is not currently supported in Windows, it was still not nice.