### PR TITLE
Add Content-Type with UTF-8 charset to notification emails

### DIFF
--- a/configs/server/burp.conf.in
+++ b/configs/server/burp.conf.in
@@ -137,6 +137,7 @@ timer_arg = Sat,Sun,00,01,02,03,04,05,06,07,08,17,18,19,20,21,22,23
 #notify_success_arg = To: youremail@example.com
 #notify_success_arg = From: @name@
 #notify_success_arg = Subject: %b succeeded: %c %w
+#notify_success_arg = Content-Type: text/plain; charset=utf-8
 # Uncomment the following to have success notifications only if there were
 # warnings.
 #notify_success_warnings_only = 1
@@ -150,6 +151,7 @@ timer_arg = Sat,Sun,00,01,02,03,04,05,06,07,08,17,18,19,20,21,22,23
 #notify_failure_arg = To: youremail@example.com
 #notify_failure_arg = From: @name@
 #notify_failure_arg = Subject: %b failed: %c %w
+#notify_failure_arg = Content-Type: text/plain; charset=utf-8
 
 # The server can run scripts on each connection after authentication and before
 # disconnecting.


### PR DESCRIPTION
Burp notification emails often contain filenames which may include national characters (as well as other characters outside ASCII). Without Content-Type header with correct charset specification these national characters are not displayed correctly until user manually changes text encoding from default ISO-8859-1 to UTF-8.

For Windows clients Burp converts everything to UTF-8, and most UNIX systems are also configured to use UTF-8 these days. Therefore I think it makes sense to add Content-Type with charset set to `utf-8` to sent messages (case doesn't matter and lowercase follows internet tradition), so that filenames could be seen correctly without manual override.

I found two places in default `burp.conf` where this header can be added. There's also a `/usr/share/burp/scripts/summary_script`, but there's no evidence it is currently being used at all, so I decided to leave it as is. Is it some historical artifact that should be removed?