### PR TITLE
Bind status port to ::1 and 127.0.0.1 by default.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -490,7 +490,7 @@ do_subst = ( sed \
   -e 's,[@]runstatedir[@],$(runstatedir),g' \
   -e 's,[@]sbindir[@],$(sbindir),g' \
   -e 's,[@]scriptdir[@],$(scriptdir),g' \
-  -e 's,[@]server_address[@],::1,g' \
+  -e 's,[@]server_address[@],localhost,g' \
   -e 's,[@]sysconfdir[@],$(sysconfdir),g' \
   -e 's,[@]name[@],$(PACKAGE_TARNAME),g' \
   -e 's,[@]package_url[@],$(PACKAGE_URL),g' \

--- a/configs/server/burp.conf.in
+++ b/configs/server/burp.conf.in
@@ -13,7 +13,8 @@ max_children = 5
 
 # Think carefully before changing the status port address, as it can be used
 # to view the contents of backups.
-#status_address = 127.0.0.1
+# Special value 'localhost' includes both ::1 and 127.0.0.1.
+#status_address = localhost
 # If you do not wish to run a status server at all, comment status_port out.
 status_port = 4972
 max_status_children = 5

--- a/docs/status-monitor.txt
+++ b/docs/status-monitor.txt
@@ -69,7 +69,7 @@ IPv4, use the --disable-ipv6 configure option).
 
 Burp-2 will listen for local connections by default. You can set the
 'status_address' option in /etc/burp/burp-server.conf to explicitly choose the
-listen address. This also lets you choose IPv4 or IPv6 at run time.
+listen address.
 
 Once you start the burp server, you may check the status address and port
 by running a command like this:

--- a/manpages/burp.8.in
+++ b/manpages/burp.8.in
@@ -225,8 +225,8 @@ Defines the main TCP address that the server listens on. The default is either '
 \fBport=[port number]\fR
 Defines the main TCP port that the server listens on. Specify multiple 'port' entries on separate lines in order to listen on multiple ports. Each port can be configured with its own 'max_children' value.
 .TP
-\fBstatus_address=[address]\fR
-Defines the main TCP address that the server listens on for status requests. The default is either '::1' or '127.0.0.1', dependent upon compile time options.
+\fBstatus_address=[address|localhost]\fR
+Defines the main TCP address that the server listens on for status requests. The default is special value 'localhost' that includes both '::1' (if available) and '127.0.0.1' (always).
 .TP
 \fBstatus_port=[port number]\fR
 Defines the TCP port that the server listens on for status requests. Comment this out to have no status server. Specify multiple 'status_port' entries on separate lines in order to listen on multiple ports. Each port can be configured with its own 'max_status_children' value.

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -419,12 +419,12 @@ static void burp_ca_conf_problem(const char *conf_path,
 #ifdef HAVE_IPV6
 // These should work for IPv4 connections too.
 #define DEFAULT_ADDRESS_MAIN	"::"
-#define DEFAULT_ADDRESS_STATUS	"::1"
 #else
 // Fall back to IPv4 address if IPv6 is not compiled in.
 #define DEFAULT_ADDRESS_MAIN	"0.0.0.0"
-#define DEFAULT_ADDRESS_STATUS	"127.0.0.1"
 #endif
+
+#define DEFAULT_ADDRESS_STATUS	"localhost"
 
 static int server_conf_checks(struct conf **c, const char *path, int *r)
 {

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -183,6 +183,17 @@ static int init_listen_sockets(const char *address, struct strlist *ports,
 	struct async *mainas, enum asfd_fdtype fdtype, const char *desc)
 {
 	struct strlist *p;
+	if(!strcmp(address, "localhost")) {
+		// If we only support "localhost" here, we can skip
+		// gethostbyname call due to RFC 6761.
+#ifdef HAVE_IPV6
+		address="::1";
+		for(p=ports; p; p=p->next)
+			// Ignore errors for IPv6 attempt.
+			init_listen_socket(address, p, mainas, fdtype, desc);
+#endif
+		address="127.0.0.1";
+	}
 	for(p=ports; p; p=p->next)
 	{
 		if(init_listen_socket(address, p, mainas, fdtype, desc))


### PR DESCRIPTION
Fix #621: Introduce special value 'localhost' for status_address that makes
burp server try to bind to ::1 first, and then bind to 127.0.0.1 anyways.
Make it default. Make 'localhost' default server address for client.