### PR TITLE
Use "always" to allow a backups anytime.

### DIFF
--- a/configs/server/burp.conf.in
+++ b/configs/server/burp.conf.in
@@ -120,10 +120,13 @@ timer_script = @scriptdir@/timer_script
 # Available units:
 # s (seconds), m (minutes), h (hours), d (days), w (weeks), n (months)
 timer_arg = 20h
+# Allow backups to start anytime
+timer_arg = always
+# To limit the timeband, do something like this:
 # Allow backups to start in the evenings and nights during weekdays
-timer_arg = Mon,Tue,Wed,Thu,Fri,00,01,02,03,04,05,19,20,21,22,23
+#timer_arg = Mon,Tue,Wed,Thu,Fri,00,01,02,03,04,05,19,20,21,22,23
 # Allow more hours at the weekend.
-timer_arg = Sat,Sun,00,01,02,03,04,05,06,07,08,17,18,19,20,21,22,23
+#timer_arg = Sat,Sun,00,01,02,03,04,05,06,07,08,17,18,19,20,21,22,23
 # Note that, if you specify no timebands, the default timer script will never
 # allow backups.
 

--- a/configs/server/timer_script
+++ b/configs/server/timer_script
@@ -32,7 +32,7 @@ while [ "$#" -gt 0 ] ; do
 	intimeband=0
 	timeband="$1"
 	case "$timeband" in
-		$curdayhour)
+		$curdayhour | "always")
 			echo "In timeband: $timeband"
 			intimeband=1
 			break


### PR DESCRIPTION
I suggest using "always" to allow backups anytime. This would be a time band that is always valid. IMHO it is better to make "always" the standard and whenever someone whishes he can limit the timeband. I'haven't updated the docs yet, but I could append it to this pull request. 