### PR TITLE
Add cifs magic number for use with exclude_fs

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -155,6 +155,7 @@ struct fstype
 };
 
 static struct fstype fstypes[]={
+	{ "cifs",		0xFF534D42 },
 	{ "btrfs",		0x9123683E },
 	{ "debugfs",		0x64626720 },
 	{ "devfs",		0x00001373 },


### PR DESCRIPTION
This seems to work allowing "exclude_fs = cifs" 

tested on 2.0.52
