### PR TITLE
727: add '-o' flag to override configuration options on the command line

### DIFF
--- a/manpages/burp.8.in
+++ b/manpages/burp.8.in
@@ -34,6 +34,10 @@ Print help and then exit.
 \fB\-?\fR \fB\fR
 Print help and then exit.
 .TP
+\fB\-o\fR \fB[option=value]\fR
+Override a given option. You can use this flag several times to override multiple options.
+You can even reset list options with the special syntax ':=' (example: '-o "include:=/tmp"').
+.TP
 \fB\-i\fR \fB\fR
 Print an index table of symbols that humans may see @name@ produce, and exit.
 .TP
@@ -83,6 +87,10 @@ Print help and then exit.
 .TP
 \fB\-?\fR \fB\fR
 Print help and then exit.
+.TP
+\fB\-o\fR \fB[option=value]\fR
+Override a given option. You can use this flag several times to override multiple options.
+You can even reset list options with the special syntax ':=' (example: '-o "include:=/tmp"').
 .TP
 \fB\-i\fR \fB\fR
 Print an index table of symbols that humans may see @name@ produce, and exit.

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -376,7 +376,7 @@ end:
 	return ret;
 }
 
-static int conf_parse_line(struct conf **confs, const char *conf_path,
+int conf_parse_line(struct conf **confs, const char *conf_path,
 	char buf[], int line)
 {
 	int ret=-1;
@@ -1055,7 +1055,7 @@ static int finalise_client_ports(struct conf **c)
 	return 0;
 }
 
-static int conf_finalise(struct conf **c)
+int conf_finalise(struct conf **c)
 {
 	enum burp_mode burp_mode=get_e_burp_mode(c[OPT_BURP_MODE]);
 	int s_script_notify=0;

--- a/src/conffile.h
+++ b/src/conffile.h
@@ -12,6 +12,8 @@ extern int conf_load_clientconfdir(struct conf **globalcs,
 	struct conf **ccconfs);
 extern int conf_load_global_only(const char *path, struct conf **globalcs);
 
+extern int conf_parse_line(struct conf **confs, const char *conf_path, char buf[], int line);
+
 extern const char *confs_get_lockfile(struct conf **confs);
 
 extern int conf_switch_to_orig_client(struct conf **globalcs,
@@ -20,6 +22,8 @@ extern int conf_switch_to_orig_client(struct conf **globalcs,
 extern int reeval_glob(struct conf **c);
 
 extern char *config_default_path(void);
+
+extern int conf_finalise(struct conf **c);
 
 #ifdef UTEST
 extern int conf_load_lines_from_buf(const char *buf, struct conf **c);


### PR DESCRIPTION
Hello,

Here is a patch that adds support for the `-o` flag as requested in #727 

Examples:

```
burp -c /tmp/burp-server.conf -t | grep restore_client                                   
                  restore_client: testclient
burp -c /tmp/burp-server.conf -t -o "restore_client=testclient2" -o "restore_client=testclient3" | grep restore_client
                  restore_client: testclient
                  restore_client: testclient2
                  restore_client: testclient3
burp -c /tmp/burp-server.conf -t -o "restore_client:=testclient3" | grep restore_client
                  restore_client: testclient3
```
