### PR TITLE
3: implement 'include_regex'

### DIFF
--- a/manpages/burp.8.in
+++ b/manpages/burp.8.in
@@ -663,7 +663,7 @@ Path to exclude from the backup. You can have multiple exclude lines. Use forwar
 Include paths that match the glob expression. For example, '/home/*/Documents' will include '/home/user1/Documents' and '/home/user2/Documents' if directories 'user1' and 'user2' exist in '/home'. The Windows implementation currently limit the expression to contain only one '*'.
 .TP
 \fBinclude_regex=[regular expression]\fR
-Not implemented.
+Include paths that match the regular expression. You need at least one 'include' or 'include_glob' option to have files to be matched against the regex. If you have at least one 'include_regex' line, then any path NOT matching the regex will be excluded from your backup.
 .TP
 \fBexclude_regex=[regular expression]\fR
 Exclude paths that match the regular expression.

--- a/src/client/find.c
+++ b/src/client/find.c
@@ -156,7 +156,6 @@ int in_exclude_comp(struct strlist *excom, const char *fname, int compression)
 
 /* Return 1 to include the file, 0 to exclude it. */
 /* Currently not used - it needs more thinking about. */
-/*
 int in_include_regex(struct strlist *increg, const char *fname)
 {
 	// If not doing include_regex, let the file get backed up.
@@ -166,7 +165,6 @@ int in_include_regex(struct strlist *increg, const char *fname)
 			return 1;
 	return 0;
 }
-*/
 
 static int in_exclude_regex(struct strlist *excreg, const char *fname)
 {
@@ -190,7 +188,8 @@ int file_is_included_no_incext(struct conf **confs, const char *fname)
 	struct strlist *best=NULL;
 
 	if(in_exclude_ext(get_strlist(confs[OPT_EXCEXT]), fname)
-	  || in_exclude_regex(get_strlist(confs[OPT_EXCREG]), fname))
+	  || in_exclude_regex(get_strlist(confs[OPT_EXCREG]), fname)
+		|| !in_include_regex(get_strlist(confs[OPT_INCREG]), fname))
 		return 0;
 
 	// Check include/exclude directories.

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -787,6 +787,12 @@ static int finalise_incexc_dirs(struct conf **c)
 		if(incexc_munge(c, s)) return -1;
 	for(s=get_strlist(c[OPT_EXCLUDE]); s; s=s->next)
 		if(incexc_munge(c, s)) return -1;
+	if(get_strlist(c[OPT_INCREG]) &&
+	   !(get_strlist(c[OPT_INCLUDE]) || get_strlist(c[OPT_INCGLOB])))
+	{
+		logp("Need at least one 'include' or 'include_glob' for the 'include_regex' to work.\n");
+		return -1;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Implement 'include_regex' according to #3 and #253.

Usage:

```
include = /home/ziirish
include = /opt/dev
include_regex = \.c$
```

This will backup only files ending with '.c' in '/home/ziirish' and '/opt/dev'
Any other (ie. **not** matching any regex) file will be excluded from the backup.