### PR TITLE
fix on upgrade script to ensure it will not stuck after execute

### DIFF
--- a/configs/server/autoupgrade/windows.script
+++ b/configs/server/autoupgrade/windows.script
@@ -1,3 +1,4 @@
+@echo off
 REM Burp used to put everything in C:\Program Files\Burp\ until 1.3.11.
 REM But still want old installations to work.
 


### PR DESCRIPTION
This fixes problems upgrading on windows 7 and 10, the script without  this always stuck.
