### PR TITLE
fix some memory leaks and revert some changes made in #746

### DIFF
--- a/src/conffile.h
+++ b/src/conffile.h
@@ -14,8 +14,6 @@ extern int conf_load_clientconfdir(struct conf **globalcs,
 	struct conf **ccconfs);
 extern int conf_load_global_only(const char *path, struct conf **globalcs);
 
-extern int conf_parse_line(struct conf **confs, const char *conf_path, char buf[], int line);
-
 extern const char *confs_get_lockfile(struct conf **confs);
 
 extern int conf_switch_to_orig_client(struct conf **globalcs,
@@ -24,8 +22,6 @@ extern int conf_switch_to_orig_client(struct conf **globalcs,
 extern int reeval_glob(struct conf **c);
 
 extern char *config_default_path(void);
-
-extern int conf_finalise(struct conf **c);
 
 #ifdef UTEST
 extern int conf_load_lines_from_buf(const char *buf, struct conf **c);


### PR DESCRIPTION
Here are some fixes for memory leaks I found while running some tests.

I also reverted some changes made in #746 (making the `conf_finalise` and `conf_parse_line` functions *private* again)