### PR TITLE
Avoid interactive question on CentOS when overwriting binary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -441,7 +441,7 @@ clean-local-check:
 $(configs): Makefile
 
 $(PACKAGE_TARNAME): main
-	$(AM_V_at)mv -v main $(PACKAGE_TARNAME)
+	$(AM_V_at)mv -fv main $(PACKAGE_TARNAME)
 
 $(PACKAGE_TARNAME).conf:
 	$(AM_V_at)rm -f $@


### PR DESCRIPTION
When building on a plain CentOS machine "mv" would ask before
replacing the "burp" binary:

---
  CCLD     main
mv: try to overwrite 'burp', overriding mode 0755 (rwxr-xr-x)?
---

Passing "-f" to "mv" avoids this question.