### PR TITLE
extra_comms: Avoid calling unlink(2) with NULL

### DIFF
--- a/src/server/extra_comms.c
+++ b/src/server/extra_comms.c
@@ -280,7 +280,8 @@ static int extra_comms_read(struct async *as,
 			const char *restore_path=get_string(
 				cconfs[OPT_RESTORE_PATH]);
 			// Client will not accept the restore.
-			unlink(restore_path);
+			if (restore_path)
+				unlink(restore_path);
 			if(set_string(cconfs[OPT_RESTORE_PATH], NULL))
 				goto end;
 			logp("Client not accepting server initiated restore.\n");


### PR DESCRIPTION
When a client has no pending server-initiated restore it could still
send the "srestore not ok" extra comm. The result is a call to unlink(2)
with a NULL path pointer. With glibc the function fails and sets errno
to EFAULT. Other implementations may be less forgiving and can segfault.