### PR TITLE
Ensure O_NOATIME is passed to system calls

### DIFF
--- a/src/bfile.c
+++ b/src/bfile.c
@@ -559,7 +559,7 @@ static int bfile_open_for_send(struct BFILE *bfd, struct asfd *asfd,
 	bfile_init(bfd, winattr, cntr);
 	if(bfile_open(bfd, asfd, fname, O_RDONLY|O_BINARY
 #ifdef O_NOATIME
-		|atime?0:O_NOATIME
+		|(atime?0:O_NOATIME)
 #endif
 		, 0))
 	{

--- a/src/fsops.c
+++ b/src/fsops.c
@@ -428,7 +428,7 @@ static int entries_in_directory(const char *path, char ***nl,
 	}
 #if defined(O_DIRECTORY) && defined(O_NOATIME)
 	int dfd=-1;
-	if((dfd=open(path, O_RDONLY|O_DIRECTORY|atime?0:O_NOATIME))<0
+	if((dfd=open(path, O_RDONLY|O_DIRECTORY|(atime?0:O_NOATIME)))<0
 	  || !(directory=fdopendir(dfd)))
 #else
 // Mac OS X appears to have no O_NOATIME and no fdopendir(), so it should


### PR DESCRIPTION
In the C programming language the "|" operator has a higher precedence
than the "?:" operator, see [1]. The expression

  O_RDONLY|O_BINARY|atime?0:O_NOATIME

used in "bfile_open" can be parenthesised as

  O_RDONLY|(O_BINARY|atime)?0:O_NOATIME

On Unix systems this happens to work as intended because Burp defines
"O_BINARY" as zero (0). The resulting system call with the "atime"
configuration option set to 0:

  open("/a/file", O_RDONLY|O_NOATIME) = 5

The case of "entries_in_directory" is similar, but in this case
"O_DIRECTORY" doesn't make it to the system call and neither does
"O_NOATIME":

  open("/a/directory", O_RDONLY) = 5

As a consequence atime is always updated on directories (unless
precluded by mount options). After adding parenthesis to the
expressions:

  open("/a/file", O_RDONLY|O_NOATIME) = 5
  open("/a/directory", O_RDONLY|O_DIRECTORY|O_NOATIME) = 5

[1] https://en.cppreference.com/w/c/language/operator_precedence