### PR TITLE
Remove unused sbuf_print_alloc_stats prototype

### DIFF
--- a/src/sbuf.h
+++ b/src/sbuf.h
@@ -72,8 +72,6 @@ extern int sbuf_to_manifest(struct sbuf *sb, struct fzp *fzp);
 
 extern int sbuf_pathcmp(struct sbuf *a, struct sbuf *b);
 
-extern void sbuf_print_alloc_stats(void);
-
 extern int sbuf_fill_from_file(struct sbuf *sb, struct fzp *fzp,
 	struct blk *blk);
 extern int sbuf_fill_from_net(struct sbuf *sb, struct asfd *asfd,


### PR DESCRIPTION
The "sbuf_print_alloc_stats" function hasn't been part of the Burp code
for a couple of years. Remove its prototype.