### PR TITLE
Implement support of keeping readall capabilities after UID/GID switch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -118,7 +118,8 @@ main_LDADD = \
 	$(NCURSES_LIBS) \
 	$(OPENSSL_LIBS) \
 	$(RSYNC_LIBS) \
-	$(ZLIBS)
+	$(ZLIBS) \
+	$(CAP_LIBS)
 
 main_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -399,7 +400,8 @@ runner_LDADD = \
 	$(NCURSES_LIBS) \
 	$(RSYNC_LIBS) \
 	$(OPENSSL_LIBS) \
-	$(ZLIBS)
+	$(ZLIBS) \
+	$(CAP_LIBS)
 
 coverage: check
 if WITH_COVERAGE

--- a/configs/client/burp.conf.in
+++ b/configs/client/burp.conf.in
@@ -54,6 +54,11 @@ server_can_restore = 0
 # Run as different user/group.
 # user=graham
 # group=nogroup
+# Set to 1 to keep 'readall' capability (linux only) when dropping privileges
+# (default is 0, do not keep capability). Readall capability allows process
+# to read all files (even not owned by user) without requiring root privileges.
+# When using readall=1 if user= is not set it's assumed nobody.
+# readall=1
 
 cross_filesystem=/home
 cross_all_filesystems=0

--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,20 @@ AC_CHECK_HEADERS([librsync.h],
 
 AC_SUBST([RSYNC_LIBS])
 
+dnl -----------------------------------------------------------
+dnl Check for headers, functions and libraries required to
+dnl support keeping readall capabilities
+dnl -----------------------------------------------------------
+
+have_readall=no
+AC_CHECK_HEADERS(sys/prctl.h sys/capability.h)
+AC_CHECK_FUNCS(prctl setreuid)
+AC_CHECK_LIB([cap], [cap_set_proc], [CAP_LIBS="-lcap"], [CAP_LIBS=])
+if test x$CAP_LIBS = x-lcap; then
+   have_readall=yes
+   AC_DEFINE(HAVE_LIBCAP, 1, [Define if you have libcap])
+fi
+AC_SUBST([CAP_LIBS])
 
 dnl --------------------------------------------------------------------------
 dnl Check whether librsync has RS_BLAKE2_SIG_MAGIC
@@ -536,6 +550,7 @@ AC_MSG_NOTICE([                   acl: ${have_acl}])
 AC_MSG_NOTICE([                 crypt: ${have_crypt}])
 AC_MSG_NOTICE([                  ipv6: ${enable_ipv6}])
 AC_MSG_NOTICE([               ncurses: ${have_ncurses}])
+AC_MSG_NOTICE([               readall: ${have_readall}])
 AC_MSG_NOTICE([               openssl: ${have_ssl}])
 AC_MSG_NOTICE([                 xattr: ${have_xattr}])
 AC_MSG_NOTICE([                  zlib: ${ac_cv_header_zlib_h}])

--- a/manpages/burp.8.in
+++ b/manpages/burp.8.in
@@ -321,6 +321,9 @@ Run as a particular user. This can be overridden by the client configuration fil
 \fBgroup=[groupname]\fR
 Run as a particular group. This can be overridden by the client configuration files in clientconfdir on the server.
 .TP
+\fBreadall=[0|1]\fR
+Keep readall capability when dropping root privileges (default 0). When enabled changes default atime to 1.
+.TP
 \fBumask=[umask]\fR
 Set the file creation umask. Default is 0022.
 .TP

--- a/src/conf.c
+++ b/src/conf.c
@@ -572,6 +572,8 @@ static int reset_conf(struct conf **c, enum conf_opt o)
 	  return sc_cntr(c[o], 0, 0, "");
 	case OPT_VSS_RESTORE:
 	  return sc_int(c[o], VSS_RESTORE_ON, 0, "");
+	case OPT_READALL:
+	  return sc_int(c[o], 0, CONF_FLAG_CC_OVERRIDE, "readall");
 	case OPT_BREAKPOINT:
 	  return sc_int(c[o], 0,
 		CONF_FLAG_CC_OVERRIDE, "breakpoint");

--- a/src/conf.h
+++ b/src/conf.h
@@ -314,6 +314,9 @@ enum conf_opt
 	// For testing.
 	OPT_BREAKPOINT,
 
+	// readall capability
+	OPT_READALL,
+
 	OPT_MAX
 };
 

--- a/src/handy.h
+++ b/src/handy.h
@@ -9,6 +9,16 @@
 
 #include "bfile.h"
 
+#undef ENABLE_KEEP_READALL_CAPS_SUPPORT
+#if defined(HAVE_SYS_PRCTL_H) && defined(HAVE_SYS_CAPABILITY_H) && \
+	defined(HAVE_PRCTL) && defined(HAVE_SETREUID) && defined(HAVE_LIBCAP)
+# include <sys/prctl.h>
+# include <sys/capability.h>
+# if defined(PR_SET_KEEPCAPS)
+#  define ENABLE_KEEP_READALL_CAPS_SUPPORT
+# endif
+#endif
+
 #define min(a,b) \
    ({ __typeof__ (a) _a = (a); \
        __typeof__ (b) _b = (b); \
@@ -23,7 +33,7 @@ extern int set_peer_env_vars(struct sockaddr_storage *addr);
 extern int set_keepalive(int fd, int value);
 extern int init_client_socket(const char *host, const char *port);
 extern void reuseaddr(int fd);
-extern int chuser_and_or_chgrp(const char *user, const char *group);
+extern int chuser_and_or_chgrp(const char *user, const char *group, int readall);
 extern int dpth_protocol1_is_compressed(int compressed, const char *datapath);
 #ifndef HAVE_WIN32
 extern void setup_signal(int sig, void handler(int sig));

--- a/src/prog.c
+++ b/src/prog.c
@@ -308,6 +308,7 @@ int real_main(int argc, char *argv[])
 	int test_confs=0;
 	enum burp_mode mode;
 	struct strlist *cli_overrides=NULL;
+	int keep_readall_caps=0;
 
 	log_init(argv[0]);
 #ifndef HAVE_WIN32
@@ -498,6 +499,12 @@ int real_main(int argc, char *argv[])
 			case ACTION_BACKUP:
 			case ACTION_BACKUP_TIMED:
 			case ACTION_TIMER_CHECK:
+#ifdef ENABLE_KEEP_READALL_CAPS_SUPPORT
+				keep_readall_caps=get_int(confs[OPT_READALL]);
+				// readall=1 cannot work with atime=0 (O_NOATIME)
+				if (keep_readall_caps)
+					set_int(confs[OPT_ATIME], 1);
+#endif
 				// Need to get the lock.
 				if(!(lock=get_prog_lock(confs)))
 					goto end;
@@ -509,7 +516,8 @@ int real_main(int argc, char *argv[])
 
 	// Change privileges after having got the lock, for convenience.
 	if(chuser_and_or_chgrp(
-		get_string(confs[OPT_USER]), get_string(confs[OPT_GROUP])))
+		get_string(confs[OPT_USER]), get_string(confs[OPT_GROUP]),
+		keep_readall_caps))
 			return -1;
 
 	set_int(confs[OPT_OVERWRITE], forceoverwrite);

--- a/src/server/child.c
+++ b/src/server/child.c
@@ -194,7 +194,7 @@ int child(struct async *as, int is_status_server,
 	if( (!confs_user  || (cconfs_user && strcmp(confs_user, cconfs_user)))
 	  ||(!confs_group ||(cconfs_group && strcmp(confs_group,cconfs_group))))
 	{
-		if(chuser_and_or_chgrp(cconfs_user, cconfs_group))
+		if(chuser_and_or_chgrp(cconfs_user, cconfs_group, 0))
 		{
 			log_and_send(as->asfd,
 				"chuser_and_or_chgrp failed on server");

--- a/utest/test_conf.c
+++ b/utest/test_conf.c
@@ -82,6 +82,7 @@ static void check_default(struct conf **c, enum conf_opt o)
 		case OPT_B_SCRIPT_POST_RUN_ON_FAIL:
 		case OPT_R_SCRIPT_POST_RUN_ON_FAIL:
 		case OPT_SEND_CLIENT_CNTR:
+		case OPT_READALL:
 		case OPT_BREAKPOINT:
 		case OPT_SYSLOG:
 		case OPT_PROGRESS_COUNTER:


### PR DESCRIPTION
This allows to run burp client without full root write access increasing
confidence in regular unattended backups as security hardening feature.

Extend chuser_and_or_chgrp() function interface to accept 3rd parameter
specifying whether process should keep capabilities required to read and
search files and directories regardless of their access permissions.

While the change itself is portable, the implementation is Linux
specific, it uses libcap to keep CAP_DAC_READ_SEARCH capability.
If libcap is not available, or OS does not have sys/prctl.h,
sys/capability.h, prctl(2), setreuid(2) and PR_SET_KEEPCAPS, then
this change is almost noop.

This is port of 2009-th bacula commit dfd9567c ("Implement support of keeping
readall capabilities after UID/GID switch") from Dmitry V. Levin
<ldv@altlinux.org>.