### PR TITLE
Add smb2 magic id

### DIFF
--- a/src/conffile.c
+++ b/src/conffile.c
@@ -199,6 +199,7 @@ static struct fstype fstypes[]={
 	{ "ramfs",		0x858458F6 },
 	{ "btrfs",		0x9123683E },
 	{ "hugetlbfs",		0x958458F6 },
+	{ "smb2",		0xFE534D42 },
 	{ "cifs",		0xFF534D42 },
 	{ NULL,			0 },
 };


### PR DESCRIPTION
Our systems recently decided to start reporting this id for cifs mounts.
```
//engineering.x.com/Tools on /home/bobr/tools type cifs (ro,relatime,vers=3.0,cache=strict,username=bobr,domain=x,uid=0,noforceuid,gid=0,noforcegid,addr=a.b.c.d,file_mode=0755,dir_mode=0755,soft,nounix,serverino,mapposix,noperm,rsize=1048576,wsize=1048576,echo_interval=60,actimeo=1)
[bobr@bobr ~:]$ ./fstype tools
0xFE534D42
```