### PR TITLE
Increasing test timeout that was causing failures on arm architectures

### DIFF
--- a/utest/test_attribs.c
+++ b/utest/test_attribs.c
@@ -115,7 +115,7 @@ Suite *suite_attribs(void)
 
 	tc_core=tcase_create("Core");
 
-	tcase_set_timeout(tc_core, 10);
+	tcase_set_timeout(tc_core, 20);
 
 	tcase_add_test(tc_core, test_attribs_protocol1);
 	tcase_add_test(tc_core, test_attribs_protocol2);


### PR DESCRIPTION
Having this timeout set to 10 was causing Ubuntu autopkgtests to fail on armhf. Increasing the timeout resolved the issue so we would like to submit the change upstream.