### PR TITLE
Fix crashes/freezes in VSS stripping code

### DIFF
--- a/src/bfile.c
+++ b/src/bfile.c
@@ -47,7 +47,7 @@ static ssize_t bfile_write_vss_strip(struct BFILE *bfd, void *buf, size_t count)
 			size_t sidlen=bsidsize-mysid->needed_s;
 			int got=min(mysid->needed_s, mycount);
 
-			memcpy(sid+sidlen, cp, got);
+			memcpy((char *)sid+sidlen, cp, got);
 
 			cp+=got;
 			mycount-=got;

--- a/src/bfile.c
+++ b/src/bfile.c
@@ -53,8 +53,13 @@ static ssize_t bfile_write_vss_strip(struct BFILE *bfd, void *buf, size_t count)
 			mycount-=got;
 			mysid->needed_s-=got;
 
-			if(!mysid->needed_s)
+			if(!mysid->needed_s) {
 				mysid->needed_d=sid->Size+sid->dwStreamNameSize;
+				// If the stream is completely empty, start
+				// reading a new VSS header.
+				if (!mysid->needed_d)
+					mysid->needed_s=bsidsize;
+			}
 		}
 		if(mysid->needed_d)
 		{


### PR DESCRIPTION
Greetings,

I ran into a couple of issues while attempting to restore a large backup from a Windows host with VSS stripping enabled:

* When VSS headers happen to span across 2 calls to bfile_write_vss_strip(), memory corruption can occur.  This manifested as a segfault for me.
* Removing VSS headers from a file containing an empty stream results in an infinite loop.  This can happen in a sparse file that has 0s at the beginning; this is the output of vss_strip -p for a file that caused the issue for me.
```VSS header: 3 2 164 0
VSS header: 1 8 0 0
VSS header: 9 8 5701640 0
VSS header: 9 8 1638408 0
VSS header: 9 8 7208968 0
VSS header: 9 8 8 0
```

There are some more details in the commit messages.

As far as I can tell, bfile_write_vss_strip() and the vss_strip tool do not properly support sparse files and will only write sections with type 1 to disk, but with these fixes I can at least restore my backup and address the sparse files some other way if needed.  I couldn't easily find the information I'd need to implement -x for BACKUP_SPARSE_BLOCK (type 9), but I'm sure I'm preaching to the choir there.

I discovered issue #895 while researching my problems, and I suspect that issue was caused either by the first bug or the lack of sparse file support.

Cheers!