### PR TITLE
Fix strip_from_path for links in restore

### DIFF
--- a/src/client/restore.c
+++ b/src/client/restore.c
@@ -865,7 +865,7 @@ int do_restore_client(struct asfd *asfd,
 					strip_from_path(sb->path.buf,
 						strip_path);
 					// Strip links if their path is absolute
-					if(sb->link.buf && !is_absolute(sb->link.buf))
+					if(sb->link.buf && is_absolute(sb->link.buf))
 						strip_from_path(sb->link.buf,
 							strip_path);
 				}


### PR DESCRIPTION
strip_from_path() was supposed to be called on link target if the path is absolute, but the opposite was the case. As a result links might not be restored properly e.g. if they point to a snapshot path.