### PR TITLE
Restoring old encrypted files can fail in 3.1.4

### DIFF
--- a/src/handy_extra.c
+++ b/src/handy_extra.c
@@ -52,6 +52,7 @@ EVP_CIPHER_CTX *enc_setup(int encrypt, const char *encryption_password,
 
 	switch(key_deriv)
 	{
+		case ENCRYPTION_NONE:
 		case ENCRYPTION_KEY_DERIVED_BF_CBC:
 			cipher=EVP_bf_cbc();
 			break;


### PR DESCRIPTION
When restoring backups that contain old files that haven't changed in a long time can result in `enc_setup()` being called with `key_deriv=0`. Restoring these files fails in this case, because `cipher` stays `NULL`, which causes `EVP_CipherInit_ex` to fail. Therefore the the `key_deriv==0` case has to be considered for the "Old, bad" way of deriving `enc_key` to work.